### PR TITLE
LD+JSON metadata fix

### DIFF
--- a/composables/metadata.ts
+++ b/composables/metadata.ts
@@ -138,7 +138,7 @@ import { ArticlePage, GalleryPage } from './types/Page'
 
   // Get <head> metadata values (for use with useHead) for an article
   function useArticlePageHeadMetadata(article: ArticlePage)
-    :{title: string, meta: {name: string, content: string}[], script: {type: string, children: string}[]}
+    :{ title: string, meta: {name: string, content: string}[] }
   {
     const metadata = {
       title: `${article.seoTitle} - Gothamist`,
@@ -155,12 +155,6 @@ import { ArticlePage, GalleryPage } from './types/Page'
         { name: 'article:modified_time', content: article.updatedDate?.toISOString() || ''},
         { name: 'article:section', content: article.section.name },
         { name: 'article:tag', content: article.tags.map(tag => tag.slug).join(',') },
-      ],
-      script: [
-        {
-            type: 'application/ld+json',
-            children: JSON.stringify(useArticlePageStructuredData(article)),
-        },
       ]
     }
     for (const author of article.authors) {
@@ -189,5 +183,6 @@ import { ArticlePage, GalleryPage } from './types/Page'
     useArticlePageTrackingData,
     useArticlePageAdTargetingData,
     useArticlePageHeadMetadata,
+    useArticlePageStructuredData,
     useGalleryPageHeadMetadata
   }

--- a/composables/useAviary.ts
+++ b/composables/useAviary.ts
@@ -8,7 +8,7 @@ export default async function useAviary(path: string, options: Record<string, an
     const config = useRuntimeConfig()
     // manually a generating fetch key here as a workaround for an issue in nuxt3 rc6
     // https://github.com/nuxt/framework/issues/5993
-    const key = path + options.toString()
+    const key = path + JSON.stringify(options)
     const {data, error} = await useFetch(path, { baseURL: config['API_URL'], key, ...options })
     const transformedData = transformResponseData(data)
     return { data: transformedData, error }

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -54,6 +54,9 @@ function useInsertAd(targetElement) {
 
 <template>
   <div>
+    <Head>
+      <Script v-if="article" type="application/ld+json" :children="JSON.stringify(useArticlePageStructuredData(article))" />
+    </Head>
     <section>
       <div class="content">
         <div v-if="article">


### PR DESCRIPTION
Structured data was getting included in the page twice when loaded through useHead(), no idea why. Loading it with the <Script> component here instead hopefully that will do what's expected.

Also included a small fix for the workaround i added for the latest nuxt rc's useFetch key creation bug