### PR TITLE
share fix and updates

### DIFF
--- a/components/Byline.vue
+++ b/components/Byline.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue'
-import { formatDateAndTime } from '~/utilities/date'
+
 import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
 import VSimpleResponsiveImage from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VSimpleResponsiveImage.vue'
 import VShareTools from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VShareTools.vue'
@@ -14,9 +14,9 @@ const props = defineProps({
 })
 
 const authors = ref(props.article.authors)
+const shareUrl = ref(props.article.url)
+const shareTitle = ref(props.article.title)
 const isMultipleAuthors = ref(props.article.authors.length > 1)
-const date = ref(formatDateAndTime(props.article?.publicationDate) || null)
-const updatedDate = ref(formatDateAndTime(props.article?.updatedDate) || null)
 const comments = ref(props.article?.comments || 'Go to')
 const isSponsored = ref(props.article?.sponsoredContent || false)
 const sponsor = ref(props.article?.sponsors[0] || [])
@@ -47,10 +47,7 @@ const sponsor = ref(props.article?.sponsors[0] || [])
         <v-flexible-link :to="sponsor.link" class="author-name">
           {{ sponsor.name }}
         </v-flexible-link>
-        <p class="type-caption">Published: {{ date }}</p>
-        <p v-if="updatedDate" class="type-caption">
-          Updated: {{ updatedDate }}
-        </p>
+        <date-published :article="props.article" />
         <v-flexible-link v-if="comments" to="#comments" class="type-textlink2">
           {{ comments }} comments
         </v-flexible-link>
@@ -106,10 +103,7 @@ const sponsor = ref(props.article?.sponsors[0] || [])
             </span>
           </span>
         </div>
-        <p class="type-caption">Published: {{ date }}</p>
-        <p v-if="updatedDate" class="type-caption">
-          Updated: {{ updatedDate }}
-        </p>
+        <date-published :article="props.article" />
         <v-flexible-link v-if="comments" to="#comments" class="type-textlink2">
           {{ comments }} comments
         </v-flexible-link>
@@ -118,21 +112,77 @@ const sponsor = ref(props.article?.sponsors[0] || [])
     <hr />
     <!-- social share -->
     <v-share-tools label="Share" class="mt-3">
-      <v-share-tools-item service="email" username="gothamist" action="share" />
       <v-share-tools-item
-        service="reddit"
-        username="gothamist"
         action="share"
-      />
-      <v-share-tools-item
-        service="twitter"
-        username="gothamist"
-        action="share"
-      />
-      <v-share-tools-item
         service="facebook"
-        username="gothamist"
+        :url="shareUrl"
+        :utm-parameters="{
+          medium: 'social',
+          source: 'facebook',
+          campaign: 'shared_facebook',
+        }"
+        @share="
+          sendEvent('click_tracking', {
+            event_category: 'Click Tracking',
+            component: 'Article Byline',
+            event_label: 'Social Share Facebook',
+          })
+        "
+      />
+
+      <v-share-tools-item
         action="share"
+        service="twitter"
+        :url="shareUrl"
+        :share-parameters="{ text: shareTitle, via: 'gothamist' }"
+        :utm-parameters="{
+          medium: 'social',
+          source: 'twitter',
+          campaign: 'shared_twitter',
+        }"
+        @share="
+          sendEvent('click_tracking', {
+            event_category: 'Click Tracking',
+            component: 'Article Byline',
+            event_label: 'Social Share Twitter',
+          })
+        "
+      />
+      <v-share-tools-item
+        action="share"
+        service="reddit"
+        :url="shareUrl"
+        :share-parameters="{ title: shareTitle }"
+        :utm-parameters="{
+          medium: 'social',
+          source: 'reddit',
+          campaign: 'shared_reddit',
+        }"
+        @share="
+          sendEvent('click_tracking', {
+            event_category: 'Click Tracking',
+            component: 'Article Byline',
+            event_label: 'Social Share Reddit',
+          })
+        "
+      />
+      <v-share-tools-item
+        action="share"
+        service="email"
+        :url="shareUrl"
+        :share-parameters="{ body: shareTitle + ' - %URL%' }"
+        :utm-parameters="{
+          medium: 'social',
+          source: 'email',
+          campaign: 'shared_email',
+        }"
+        @share="
+          sendEvent('click_tracking', {
+            event_category: 'Click Tracking',
+            component: 'Article Byline',
+            event_label: 'Social Share Email',
+          })
+        "
       />
     </v-share-tools>
     <hr class="mt-3 mb-5 xxl:hidden" />

--- a/components/DatePublished.vue
+++ b/components/DatePublished.vue
@@ -29,6 +29,7 @@ const props = defineProps({
   },
 })
 
+// function to format the date based on being fuzzy or showing the prefix
 const createDateLine = (date, prefix) => {
   if (date) {
     if (props.fuzzy) {

--- a/components/DatePublished.vue
+++ b/components/DatePublished.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { formatDateForByline, fuzzyDateTime } from '~/utilities/date'
+import { ref } from 'vue'
+
+const props = defineProps({
+  article: {
+    type: Object,
+    default: null,
+  },
+  fuzzy: {
+    type: Boolean,
+    default: false,
+  },
+  showPrefix: {
+    type: Boolean,
+    default: true,
+  },
+  typeClass: {
+    type: String,
+    default: 'type-caption',
+  },
+  prefix: {
+    type: String,
+    default: 'Published: ',
+  },
+  prefixModified: {
+    type: String,
+    default: 'Modified: ',
+  },
+})
+
+const createDateLine = (date, prefix) => {
+  if (date) {
+    if (props.fuzzy) {
+      return `${prefix}${fuzzyDateTime(date)}`
+    } else {
+      return `${prefix}${formatDateForByline(date)}`
+    }
+  }
+  {
+    return null
+  }
+}
+const prefix = ref(props.showPrefix ? props.prefix : '')
+const prefixModified = ref(props.showPrefix ? props.prefixModified : '')
+
+const date = ref(createDateLine(props.article?.publicationDate, prefix.value))
+const modifiedDate = ref(
+  createDateLine(props.article?.updatedDate, prefixModified.value)
+)
+</script>
+
+<template>
+  <div class="date-published">
+    <p :class="props.typeClass">{{ date }}</p>
+    <p v-if="modifiedDate" :class="props.typeClass">
+      {{ modifiedDate }}
+    </p>
+  </div>
+</template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@nypublicradio/nypr-design-system-vue3": "^0.3.25",
+        "@nypublicradio/nypr-design-system-vue3": "^0.3.26",
         "@sentry/tracing": "^6.18.2",
         "@sentry/vue": "^6.18.2",
         "@vitejs/plugin-vue": "^2.3.2",
@@ -2274,9 +2274,9 @@
       }
     },
     "node_modules/@nypublicradio/nypr-design-system-vue3": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.3.25/038d68062812309a2316d3860dffd2d6cc146f9a93c6dc022d000825d9f84c63",
-      "integrity": "sha512-fp7nMeWO3JIBlrljJu0DQ/oVstwk4MM8gEwALPgTa1VypgXqVd4Tau588MZJIWbl4gvZP+PdJE/0AE2rFvQKug==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.3.26/00d1a24778e3d9ca2f1056381b268b618030b715955fd90719b768bed9eaf667",
+      "integrity": "sha512-D13bb2qV5P3A21vLpmcCjAvOiTk9h4ig0Jp4PSr/BHgPqSI2lDWiEwfictbcvyIyIMnk0ZNAalWKy4/biTVwQQ==",
       "dependencies": {
         "@nuxt/vite-builder": "^3.0.0-rc.4",
         "axios": "^0.25.0",
@@ -16416,9 +16416,9 @@
       }
     },
     "@nypublicradio/nypr-design-system-vue3": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.3.25/038d68062812309a2316d3860dffd2d6cc146f9a93c6dc022d000825d9f84c63",
-      "integrity": "sha512-fp7nMeWO3JIBlrljJu0DQ/oVstwk4MM8gEwALPgTa1VypgXqVd4Tau588MZJIWbl4gvZP+PdJE/0AE2rFvQKug==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.3.26/00d1a24778e3d9ca2f1056381b268b618030b715955fd90719b768bed9eaf667",
+      "integrity": "sha512-D13bb2qV5P3A21vLpmcCjAvOiTk9h4ig0Jp4PSr/BHgPqSI2lDWiEwfictbcvyIyIMnk0ZNAalWKy4/biTVwQQ==",
       "requires": {
         "@nuxt/vite-builder": "^3.0.0-rc.4",
         "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@nypublicradio/nypr-design-system-vue3": "^0.3.25",
+    "@nypublicradio/nypr-design-system-vue3": "^0.3.26",
     "@sentry/tracing": "^6.18.2",
     "@sentry/vue": "^6.18.2",
     "@vitejs/plugin-vue": "^2.3.2",

--- a/utilities/date.ts
+++ b/utilities/date.ts
@@ -24,15 +24,13 @@ export const fuzzyDateTime = function (time: Date): string {
 }
 
 // formats a date in the format of ShortMonthName DD, YYYY
-export const formatDateAndTime = function (date) {
-  if (!date) return null
-  const formattedDate = new Date(date)
-  const day = formattedDate.getDate()
-  const month = formattedDate.toLocaleString('default', { month: 'short' })
-  const year = formattedDate.getFullYear()
-  const hours = formattedDate.getHours()
-  const minutes = (formattedDate.getMinutes() < 10 ? '0' : '') + formattedDate.getMinutes()
-  const hour = ((hours + 11) % 12 + 1)
-  const suffix = hour >= 12 ? "pm" : "am";
-  return `${month} ${day}, ${year} at ${hour}:${minutes}${suffix}`
+export const formatDateForByline = function (date) {
+  if (date) {
+    const dateObject = new Date(date)
+    const now = new Date()
+    const shortDate = format(dateObject, 'MMM d, y')
+    const longDate = format(dateObject, "MMM d, y 'at' h:mm aaaa")
+    return differenceInHours(now, dateObject) <= 12 ? longDate : shortDate
+  }
+  return null
 }


### PR DESCRIPTION
- Fixed the VShareToolsItem comp so it actually shares
- updated the time formatting function to match the old Gothamist rules for <12 hours… etc… as requested
- broke out dates into a stand alone component(DatePublished.vue)
props:

  article: {
    type: Object,
    default: null,
  },
  fuzzy: {
    type: Boolean,
    default: false,
  },
  showPrefix: {
    type: Boolean,
    default: true,
  },
  typeClass: {
    type: String,
    default: 'type-caption',
  },
  prefix: {
    type: String,
    default: 'Published: ',
  },
  prefixModified: {
    type: String,
    default: 'Modified: ',
  },