### PR TITLE
Bono/goth 386

### DIFF
--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -14,6 +14,7 @@ const profileData = isSponsored.value
   ? props.article?.sponsors
   : props.article.authors
 
+// function attached to the emit of the article-tags when clicked
 const onTagClicked = (tag) => {
   sendEvent('click_tracking', {
     event_category: 'Click Tracking',

--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -18,7 +18,7 @@ const profileData = isSponsored.value
 <template>
   <div class="article-footer">
     <!-- tags -->
-    <article-tags :tags="tags" />
+    <article-tags :tags="tags" @tagClicked="console.log('tag clicked')" />
     <!-- profile & comments-->
     <hr class="black mb-6" />
     <div class="grid">

--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -13,12 +13,20 @@ const isSponsored = ref(props.article?.sponsoredContent || false)
 const profileData = isSponsored.value
   ? props.article?.sponsors
   : props.article.authors
+
+const onTagClicked = (tag) => {
+  sendEvent('click_tracking', {
+    event_category: 'Click Tracking',
+    component: 'Article Tags',
+    event_label: tag.name,
+  })
+}
 </script>
 
 <template>
   <div class="article-footer">
     <!-- tags -->
-    <article-tags :tags="tags" @tagClicked="console.log('tag clicked')" />
+    <article-tags :tags="tags" @tag-clicked="onTagClicked" />
     <!-- profile & comments-->
     <hr class="black mb-6" />
     <div class="grid">

--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref } from 'vue'
-import VTag from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VTag.vue'
 
 const props = defineProps({
   article: {
@@ -19,15 +18,7 @@ const profileData = isSponsored.value
 <template>
   <div class="article-footer">
     <!-- tags -->
-    <div v-if="tags" class="tags flex gap-1 align-items-center pb-6">
-      <p class="type-caption mr-3">Tagged</p>
-      <v-tag
-        v-for="tag in tags"
-        :name="tag.name"
-        :slug="tag.slug"
-        :key="tag.name"
-      />
-    </div>
+    <article-tags :tags="tags" />
     <!-- profile & comments-->
     <hr class="black mb-6" />
     <div class="grid">
@@ -46,7 +37,10 @@ const profileData = isSponsored.value
       </div>
       <div class="col-fixed mx-auto">
         <!-- <div class="htlad-index_rectangle_1" /> -->
-        <img src="https://fakeimg.pl/300x250/?text=AD Here" />
+        <img
+          src="https://fakeimg.pl/300x250/?text=AD Here"
+          style="width: 100%; max-width: 300px"
+        />
         <p class="type-fineprint">Powered by members and sponsors</p>
       </div>
     </div>

--- a/components/ArticleTags.vue
+++ b/components/ArticleTags.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { useRuntimeConfig } from '#app'
 import VTag from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VTag.vue'
 const props = defineProps({
   tags: {
@@ -11,7 +10,6 @@ const props = defineProps({
     default: 'Tagged',
   },
 })
-const config = useRuntimeConfig()
 const emit = defineEmits(['tag-clicked'])
 </script>
 
@@ -24,7 +22,7 @@ const emit = defineEmits(['tag-clicked'])
       <v-tag
         v-for="tag in props.tags"
         :name="tag.name"
-        :slug="`/tags/${tag.slug}`"
+        :slug="`/news`"
         :key="tag.name"
         @click="emit('tag-clicked', tag)"
       />

--- a/components/ArticleTags.vue
+++ b/components/ArticleTags.vue
@@ -1,0 +1,32 @@
+<script setup>
+import VTag from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VTag.vue'
+const props = defineProps({
+  tags: {
+    type: Array,
+    default: null,
+  },
+  label: {
+    type: String,
+    default: 'Tagged',
+  },
+})
+
+const emit = defineEmits(['tag-clicked'])
+</script>
+
+<template>
+  <div v-if="props.tags" class="tags flex align-items-start pb-6">
+    <p v-if="props.label" class="type-caption mr-3 mt-0 lg:mt-1">
+      {{ props.label }}
+    </p>
+    <div class="flex gap-1 align-items-center flex-wrap">
+      <v-tag
+        v-for="tag in props.tags"
+        :name="tag.name"
+        :slug="tag.slug"
+        :key="tag.name"
+        @click="emit('tag-clicked', tag)"
+      />
+    </div>
+  </div>
+</template>

--- a/components/ArticleTags.vue
+++ b/components/ArticleTags.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useRuntimeConfig } from '#app'
 import VTag from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VTag.vue'
 const props = defineProps({
   tags: {
@@ -10,7 +11,7 @@ const props = defineProps({
     default: 'Tagged',
   },
 })
-
+const config = useRuntimeConfig()
 const emit = defineEmits(['tag-clicked'])
 </script>
 
@@ -23,7 +24,7 @@ const emit = defineEmits(['tag-clicked'])
       <v-tag
         v-for="tag in props.tags"
         :name="tag.name"
-        :slug="tag.slug"
+        :slug="`/tags/${tag.slug}`"
         :key="tag.name"
         @click="emit('tag-clicked', tag)"
       />

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -106,7 +106,10 @@ function useInsertAd(targetElement) {
           </div>
           <div class="col-fixed hidden lg:block">
             <!-- <div class="htlad-index_rectangle_1" /> -->
-            <img src="https://fakeimg.pl/300x250/?text=AD Here" />
+            <img
+              src="https://fakeimg.pl/300x250/?text=AD Here"
+              style="width: 100%; max-width: 300px"
+            />
             <p class="type-fineprint">Powered by members and sponsors</p>
           </div>
         </div>
@@ -152,7 +155,8 @@ $article-fixed-width: 316px;
     background: transparent;
   }
   .col-fixed {
-    width: $article-fixed-width;
+    width: 100%;
+    max-width: $article-fixed-width;
   }
 }
 </style>


### PR DESCRIPTION
moved the tags in to it's own component

props:
tags:array
label:string

have an emit on tag click that calls a gaEvent on the ArticleFooter.