### PR TITLE
wcolon/DEVO-260

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
               --task-role=$ROLE \
               --environment=$ENV \
               --tag=$TAG \
-              --wait=300
+              --wait=300 \
               --enable-execute-command
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
               --environment=$ENV \
               --tag=$TAG \
               --wait=300
+              --enable-execute-command
 
 commands:
   setup_npmrc:


### PR DESCRIPTION
Enable execute command to grant shell access to troubleshoot the timeout issue occurring in the container. 
