### PR TITLE
wcolon/DEVO-262

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - checkout
       - setup_npmrc
       - setup_remote_docker:
-          version: 19.03.13            
+          version: 20.10.12            
       - run:
           name: Deploy
           environment:
@@ -103,8 +103,8 @@ jobs:
             
             nyprsetuptools DockerDeploy \
               --fargate \
-              --cpu=256 \
-              --memory-reservation=512 \
+              --cpu=512 \
+              --memory-reservation=1024 \
               --ecr-repository=gothamist-vue3 \
               --ecs-cluster=gothamist-vue3 \
               --ports=3000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ jobs:
             
             nyprsetuptools DockerDeploy \
               --fargate \
-              --cpu=512 \
-              --memory-reservation=1024 \
+              --cpu=1024 \
+              --memory-reservation=2048 \
               --ecr-repository=gothamist-vue3 \
               --ecs-cluster=gothamist-vue3 \
               --ports=3000 \


### PR DESCRIPTION
I've increased the amount VCPU and memory allocated to the container. Originally set at 1/4 vcpu and 1/2 GB of ram to 1 vcpu and 2GB. This update has been tested on demo and it's manage to improve the time to load the site. 