### PR TITLE
Add header, sidebar, homepage topper

### DIFF
--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -1,18 +1,16 @@
-<script setup>
+<script setup lang="ts">
 import VShareTools from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VShareTools.vue'
 import VShareToolsItem from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VShareToolsItem.vue'
 import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
+import Navigation from '~~/composables/types/Navigation.js';
 
-const props = defineProps({
-  navData: {
-    type: Object,
-    default: null,
-  },
-})
+const props = defineProps<{
+  navigation: Navigation
+}>()
 
-const legalLinks = ref(props.navData.legalLinks)
-const propertyDescription = ref(props.navData.propertyDescription)
-const copyrightYear = ref(props.navData.copyrightYear)
+const legalLinks = ref(props.navigation.legalLinks)
+const propertyDescription = ref(props.navigation.propertyDescription)
+const copyrightYear = ref(props.navigation.copyrightYear)
 </script>
 
 <template>
@@ -24,7 +22,7 @@ const copyrightYear = ref(props.navData.copyrightYear)
     <div class="content">
       <div class="top grid">
         <div class="hidden lg:flex lg:col-3 xl:col-4 p-0">
-          <menu-list :navData="props.navData" />
+          <menu-list :navLinks="props.navigation.primaryFooterLinks" />
         </div>
         <div class="col-12 lg:col-9 xl:col-8 right p-0">
           <div class="logo-lockup">
@@ -37,7 +35,7 @@ const copyrightYear = ref(props.navData.copyrightYear)
             ></div>
           </div>
           <div class="block lg:hidden">
-            <menu-list :navData="props.navData" />
+            <menu-list :navLinks="props.navigation.primaryFooterLinks" />
           </div>
           <nypr-logos-bracket />
         </div>
@@ -153,7 +151,7 @@ const copyrightYear = ref(props.navData.copyrightYear)
           a {
             @include font-config($type-fineprint);
           }
-          @include media('<lg') {
+          @include media('<md') {
             flex-direction: column;
           }
         }

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import Navigation from '~~/composables/types/Navigation.js';
+import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
+import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
+import { ArticlePage } from '~~/composables/types/Page.js';
+
+const props = defineProps<{
+    articles: ArticlePage[]
+    navigation: Navigation
+}>()
+
+const featuredArticle = props.articles[0]
+const latestArticles = props.articles.slice(1)
+</script>
+
+<template v-if="featuredArticle && latestArticles">
+    <div class="homepage-topper grid mb-6 gutter-x-30">
+        <div class="col-12 flex align-items-end mb-2" >
+            <menu-list class="homepage-topper-navigation hidden md:flex col-fixed p-0" :navLinks="navigation.primaryNavigation" />
+            <LogoGothamist class="homepage-topper-logo col p-0"></LogoGothamist>
+        </div>
+        <div class="col-12 xl:col-8">
+            <v-card
+                class="featured-article mod-vertical mod-featured mod-large"
+                :image="useImageUrl(featuredArticle.listingImage)"
+                :sizes="[1]"
+                :width="897"
+                :height="598"
+                :title="featuredArticle.title"
+                :titleLink="featuredArticle.link"
+                :maxWidth="featuredArticle.listingImage.width"
+                :maxHeight="featuredArticle.listingImage.height"
+                :tags="[
+                    {
+                    name: featuredArticle.section.name,
+                    slug: `/${featuredArticle.section.slug}`,
+                    },
+                ]"
+            >
+            <p class="desc">
+                {{ featuredArticle.description }}
+            </p>
+            <v-card-metadata :article="featuredArticle" />
+            </v-card>
+        </div>
+        <div class="col-12 xl:col-4">
+            <hr class="black mb-1" />
+            <v-flexible-link class="mb-3 -ml-3" to="#latest" raw>
+                <Button
+                    class="p-button-text p-button-rounded button-pill-icon"
+                    icon="pi pi-arrow-right ml-2"
+                    iconPos="right"
+                    label="LATEST"
+                />
+            </v-flexible-link>
+            <div v-for="article in latestArticles" :key="article.uuid">
+                <v-card
+                    class="mod-horizontal mod-left mod-small mb-3 tag-small"
+                    :image="useImageUrl(article.listingImage)"
+                    :width="158"
+                    :height="106"
+                    :sizes="[1]"
+                    :title="article.title"
+                    :titleLink="article.link"
+                    :maxWidth="article.listingImage.width"
+                    :maxHeight="article.listingImage.height"
+                    :quality="80"
+                >
+                    <v-card-metadata :article="article" :showComments="false" />
+                </v-card>
+            </div>
+            <img
+            class="mb-1"
+            src="https://fakeimg.pl/450x250/?text=AD Here"
+            style="max-width: 100%"
+            width="450"
+            height="250"
+            alt="advertisement"
+            />
+            <p class="text-sm text-gray-400">
+                Powered by members and sponsors
+            </p>
+        </div>
+    </div>
+</template>
+
+<style lang="scss">
+
+.homepage-topper-navigation {
+    width: 225px;
+    @include media('>lg') {
+        width:300px;
+    }
+}
+
+.homepage-topper-logo {
+    height: auto;
+}
+</style>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
-import Navigation from '~~/composables/types/Navigation.js';
+import { computed } from 'vue'
 import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { ArticlePage } from '~~/composables/types/Page.js';
+import Navigation from '~~/composables/types/Navigation.js';
 
 const props = defineProps<{
     articles: ArticlePage[]
     navigation: Navigation
 }>()
 
-const featuredArticle = props.articles[0]
-const latestArticles = props.articles.slice(1)
+const featuredArticle = computed(() => props.articles[0])
+const latestArticles = computed(() => props.articles.slice(1))
 </script>
 
 <template v-if="featuredArticle && latestArticles">

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -44,7 +44,7 @@ const latestArticles = computed(() => props.articles.slice(1))
             <v-card-metadata :article="featuredArticle" />
             </v-card>
         </div>
-        <div class="col-12 xl:col-4">
+        <div class="col-12 xl:col-4 flex flex-column justify-content-end">
             <hr class="black mb-1" />
             <v-flexible-link class="mb-3 -ml-3" to="#latest" raw>
                 <Button

--- a/components/GothamistMainHeader.vue
+++ b/components/GothamistMainHeader.vue
@@ -23,7 +23,7 @@ const sideBarVisible = ref(false);
             </div>
         </div>
         <div class="gothamist-header-right">
-            <v-flexible-link :to="donateUrl" raw class="pr-2">
+            <v-flexible-link :to="`${donateUrl}&utm_campaign=brandheader`" raw class="pr-2">
                 <Button class="gothamist-header-donate-button p-button-rounded"> 
                     <span class="p-button-label">Donate</span>
                 </Button>

--- a/components/GothamistMainHeader.vue
+++ b/components/GothamistMainHeader.vue
@@ -23,7 +23,7 @@ const sideBarVisible = ref(false);
             </div>
         </div>
         <div class="gothamist-header-right">
-            <v-flexible-link :to="`${donateUrl}&utm_campaign=brandheader`" raw class="pr-2">
+            <v-flexible-link :to="`${donateUrl}&utm_campaign=goth_header`" raw class="pr-2">
                 <Button class="gothamist-header-donate-button p-button-rounded"> 
                     <span class="p-button-label">Donate</span>
                 </Button>

--- a/components/GothamistMainHeader.vue
+++ b/components/GothamistMainHeader.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import GothamistSidebarContents from "./GothamistSidebarContents.vue";
+import Navigation from "~~/composables/types/Navigation";
+import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
+
+defineProps<{
+    showLogo: boolean,
+    navigation: Navigation
+    donateUrl: string
+}>()
+
+const sideBarVisible = ref(false);
+</script>
+
+<template>
+    <header class="gothamist-header flex justify-content-between">
+        <div class="gothamist-header-left">
+            <v-flexible-link to="/" raw>
+                <LogoGothamist v-if="showLogo" class="gothamist-header-logo pr-2" />
+            </v-flexible-link>
+            <div :class="`gothamist-header-tagline ${showLogo ? 'hidden' : 'block' } md:block`">
+                News for New Yorkers
+            </div>
+        </div>
+        <div class="gothamist-header-right">
+            <v-flexible-link :to="donateUrl" raw class="pr-2">
+                <Button class="gothamist-header-donate-button p-button-rounded"> 
+                    <span class="p-button-label">Donate</span>
+                </Button>
+            </v-flexible-link>
+            <Button icon="pi pi-bars" class="p-button p-component p-button-icon-only p-button-text p-button-rounded" @click="sideBarVisible = true" />
+            <Sidebar 
+                v-model:visible="sideBarVisible" 
+                position="right" 
+                data-style-mode="dark" 
+                class="gothamist-sidebar px-3 md:px-4">
+                <template v-slot:header>
+                    <div class="gothamist-sidebar-header flex md:hidden">
+                        <v-flexible-link to="/" raw>
+                            <LogoGothamist class="gothamist-sidebar-header-logo pr-2" />
+                        </v-flexible-link>
+                        <div class="gothamist-sidebar-header-tagline">
+                            News for New Yorkers
+                        </div>
+                    </div>
+                </template>
+                <template v-slot:default>
+                    <GothamistSidebarContents
+                        :navigation="navigation" 
+                        :donateUrl="donateUrl" 
+                        class="mt-3"
+                    />
+                </template>
+            </SideBar>
+        </div>
+    </header>
+</template>
+
+<style lang="scss">
+.gothamist-header {
+    width: 100%;
+    height: 68px;
+    padding: 1rem 1.5rem;
+    @include media('>md') {
+      padding: 1rem 2.5rem;
+    }
+    display: flex;
+}
+.gothamist-header-logo {
+    height: 34px;
+    width: auto;
+}
+
+.gothamist-header-left, .gothamist-header-center, .gothamist-header-right {
+    align-items: flex-end;
+    display: flex
+}
+
+.gothamist-header-donate-button {
+    max-height: 36px;
+}
+
+.gothamist-header-tagline {
+    font-family: var(--font-family-header);
+    font-size: 14px;
+    line-height: var(--font-size-6);
+    font-weight: 600;
+    color: black;
+    width: 86px;
+    align-self: flex-end;
+}
+
+.gothamist-sidebar.p-sidebar-right {
+    background-color: var(--black-500);
+    width: 100vw;
+    @include media('>sm') {
+        width: 480px;
+    }
+    .p-sidebar-close {
+        color: white;
+    }
+}
+
+.gothamist-sidebar .p-sidebar-header {
+    justify-content: space-between;
+    padding: 1rem 0 0 0;
+}
+
+.gothamist-sidebar .p-sidebar-header {
+    align-items: flex-end;
+}
+
+.gothamist-sidebar-header-logo {
+    width: 120px;
+    padding-bottom: 3px;
+    height: auto;
+    * {
+        fill: white;
+    }
+}
+
+.gothamist-sidebar-header-tagline {
+    width: 100px;
+    color: white;
+}
+
+.gothamist-sidebar .p-sidebar-content {
+    padding: 0;
+}
+
+.p-sidebar-mask {
+    background-color: rgba(0,0,0,0.8) !important;
+}
+</style>

--- a/components/GothamistSidebarContents.vue
+++ b/components/GothamistSidebarContents.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import VShareTools from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VShareTools.vue'
+import VShareToolsItem from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VShareToolsItem.vue'
+import Navigation from '~~/composables/types/Navigation.js';
+import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue';
+
+const props = defineProps<{
+    navigation: Navigation
+    donateUrl: string
+}>()
+</script>
+
+<template>
+    <div class="sidebar-contents pt-3">
+        <div class="sidebar-contents-top pb-5">
+            <menu-list :navLinks="props.navigation.primaryNavigation" />
+        </div>
+        <div class="sidebar-contents-bottom mb-5 md:mb-6">
+            <v-flexible-link to="mailto:tips@gothamist.com" raw>
+                <Button class="sidebar-button-send-a-story p-button-rounded mb-5 w-full">
+                    <span class="p-button-label">Send a story idea</span>
+                </Button>
+            </v-flexible-link>
+            <hr class="white mb-3" />
+            <v-share-tools class="mb-3">
+                <span>Follow Us</span>
+                <v-share-tools-item service="facebook" username="gothamist" />
+                <v-share-tools-item service="twitter" username="gothamist" />
+                <v-share-tools-item service="instagram" username="gothamist" />
+                <v-share-tools-item
+                    service="youtube"
+                    username="UCY_2VeS5Q9_sMZRhtvF0c5Q"
+                />
+            </v-share-tools>
+            <hr class="white mb-3" />
+            <div class="flex mb-3">
+                <div class="mr-2">Replace this message with a thing about being non profit, member funded local news.</div>
+                <div><LogoNypr /></div>
+            </div>
+            <v-flexible-link :to="donateUrl" raw>
+                <Button class="p-button-rounded w-full">
+                    <span class="p-button-label">
+                        <span class="pi pi-heart-fill"></span>
+                        Support us today
+                    </span>
+                </Button>
+            </v-flexible-link>
+        </div>
+    </div>
+</template>
+
+<style lang="scss">
+.sidebar-contents {
+    min-height: calc(100vh - 80px);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    color: var(--text-color);
+}
+
+.sidebar-contents .menu-list {
+    gap: 1.5rem;
+}
+
+.sidebar-contents .menu-list a.flexible-link {
+    font-family: var(--font-family-header);
+    text-transform: none;
+    font-weight: 600;
+    font-size: 26px;
+    @include media('>sm') {
+        font-size: 32px;
+    }
+}
+
+.sidebar-button-send-a-story.p-button {
+    background: var(--black-300);
+    color: var(--text-color);
+}
+</style>

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -1,22 +1,17 @@
-<script setup>
-import { ref } from 'vue'
+<script setup lang="ts">
+import NavigationLink from "./NavigationLink";
 import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
 
-const props = defineProps({
-  navData: {
-    type: Object,
-    default: null,
-    required: true,
-  },
-})
+defineProps<{
+  navLinks: NavigationLink[],
+}>()
 
-const primaryFooterLinks = ref(props.navData.primaryFooterLinks)
 </script>
 
 <template>
   <div class="menu-list">
     <v-flexible-link
-      v-for="(item, index) in primaryFooterLinks"
+      v-for="(item, index) in navLinks"
       :to="item.value.url"
       :key="`primaryFooterLinks-${index}`"
     >
@@ -30,7 +25,7 @@ const primaryFooterLinks = ref(props.navData.primaryFooterLinks)
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  @include media('<lg') {
+  @include media('<md') {
     gap: 1rem;
   }
   .flexible-link {

--- a/composables/states.ts
+++ b/composables/states.ts
@@ -1,2 +1,14 @@
+import Navigation from "./types/Navigation"
+
 export const useSensitiveContent = () => useState<boolean>('sensitiveContent', () => false)
 export const useMembershipStatus = () => useState<string>('membershipStatus', () => 'status-unknown')
+export const useNavigation = () => useState<Navigation>('navigation', () => ({
+    id: 0,
+    primaryNavigation: [],
+    secondaryNavigation: [],
+    primaryFooterLinks: [],
+    secondaryFooterLinks: [],
+    legalLinks: [],
+    copyrightYear: '',
+    propertyDescription: ''
+}))

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -83,7 +83,7 @@ watch(route, (value) => {
     <GothamistMainHeader 
       :navigation="navigation"
       :showLogo="route.name !== 'index'"
-      :donateUrl="config.DONATE_URL"
+      :donateUrl="config.donateUrlBase"
     />
     <main>
       <slot />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,6 +9,9 @@ const atTop = ref(true)
 const navigation = await findNavigation().then(({ data }) =>
   normalizeFindNavigationResponse(data)
 )
+const navigationState = useNavigation()
+navigationState.value = navigation
+
 const breakingNews = await findBreakingNews().then(({ data }) =>
   normalizeFindBreakingNewsResponse(data)
 )
@@ -77,26 +80,18 @@ watch(route, (value) => {
       </Head>
     </Html>
     <div v-if="!sensitiveContent" class="htlad-skin" />
-    <header>
-      <h1><NuxtLink to="/">Gothamist</NuxtLink></h1>
-      <!-- Header -->
-    </header>
+    <GothamistMainHeader 
+      :navigation="navigation"
+      :showLogo="route.name !== 'index'"
+      :donateUrl="config.DONATE_URL"
+    />
     <main>
       <slot />
     </main>
     <scroll-to-top-button />
-    <gothamist-footer :navData="navigation" />
+    <gothamist-footer :navigation="navigation" />
   </div>
 </template>
 
 <style lang="scss">
-body,
-html {
-  //overflow-y: auto;
-  //overflow-x: hidden;
-}
-
-main {
-  padding-top: var(--header-height);
-}
 </style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -86,6 +86,7 @@ export default defineNuxtConfig({
     navigationId: 1,
     systemMessagesId: 2,
     sitewideComponentsId: 2,
+    DONATE_URL: "https://pledge.wnyc.org/support/gothamist?utm_medium=redirect&utm_source=wnyc&utm_campaign=gothamist&utm_medium=partnersite&utm_source=gothamist&utm_campaign=brandheader"
   },
   typescript: {
     strict: true

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -86,7 +86,6 @@ export default defineNuxtConfig({
     navigationId: 1,
     systemMessagesId: 2,
     sitewideComponentsId: 2,
-    DONATE_URL: "https://pledge.wnyc.org/support/gothamist?utm_medium=redirect&utm_source=wnyc&utm_campaign=gothamist&utm_medium=partnersite&utm_source=gothamist&utm_campaign=brandheader"
   },
   typescript: {
     strict: true

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -178,27 +178,8 @@ const newsletterSubmitEvent = (e) => {
 </template>
 
 <style lang="scss">
-.sectionSlug-articleSlug {
-  .top-section {
-    background: var(--soybean200);
-    background: -moz-linear-gradient(
-      top,
-      var(--soybean200) 17%,
-      var(--white) 100%
-    );
-    background: -webkit-linear-gradient(
-      top,
-      var(--soybean200) 17%,
-      var(--white) 100%
-    );
-    background: linear-gradient(
-      to bottom,
-      var(--soybean200) 17%,
-      var(--white) 100%
-    );
-    background-size: 100% 720px !important;
-    background-repeat: no-repeat !important;
-  }
+.page.sectionSlug-articleSlug {
+  background: linear-gradient(180deg, #F3F3E4 0, rgba(255, 255, 255, 0) 720px, rgba(255, 255, 255, 0) 100%);
   .v-tag .p-button {
     background: transparent;
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -38,6 +38,7 @@ const newsletterSubmitEvent = (e) => {
   //   event_label: 'Become a member',
   // })
 }
+const navigation = useNavigation()
 
 onMounted(() => {
   const { $analytics } = useNuxtApp()
@@ -49,73 +50,10 @@ onMounted(() => {
   <div>
     <section>
       <div class="content">
-        <!-- featured and latest articles -->
-        <template v-if="featuredArticle && latestArticles">
-          <div class="grid mb-6 gutter-x-30">
-            <div class="col-12 xl:col-8">
-              <v-card
-                class="featured-article mod-vertical mod-featured mod-large"
-                :image="useImageUrl(featuredArticle.listingImage)"
-                :sizes="[1]"
-                :width="897"
-                :height="598"
-                :title="featuredArticle.title"
-                :titleLink="featuredArticle.link"
-                :maxWidth="featuredArticle.listingImage.width"
-                :maxHeight="featuredArticle.listingImage.height"
-                :tags="[
-                  {
-                    name: featuredArticle.section.name,
-                    slug: `/${featuredArticle.section.slug}`,
-                  },
-                ]"
-              >
-                <p class="desc">
-                  {{ featuredArticle.description }}
-                </p>
-                <v-card-metadata :article="featuredArticle" />
-              </v-card>
-            </div>
-            <div class="col-12 xl:col-4">
-              <hr class="black mb-1" />
-              <v-flexible-link class="mb-3 -ml-3" to="#latest" raw>
-                <Button
-                  class="p-button-text p-button-rounded button-pill-icon"
-                  icon="pi pi-arrow-right ml-2"
-                  iconPos="right"
-                  label="LATEST"
-                />
-              </v-flexible-link>
-              <div v-for="article in latestArticles" :key="article.uuid">
-                <v-card
-                  class="mod-horizontal mod-left mod-small mb-3 tag-small"
-                  :image="useImageUrl(article.listingImage)"
-                  :width="158"
-                  :height="106"
-                  :sizes="[1]"
-                  :title="article.title"
-                  :titleLink="article.link"
-                  :maxWidth="article.listingImage.width"
-                  :maxHeight="article.listingImage.height"
-                  :quality="80"
-                >
-                  <v-card-metadata :article="article" :showComments="false" />
-                </v-card>
-              </div>
-              <img
-                class="mb-1"
-                src="https://fakeimg.pl/450x250/?text=AD Here"
-                style="max-width: 100%"
-                width="450"
-                height="250"
-                alt="advertisement"
-              />
-              <p class="text-sm text-gray-400">
-                Powered by members and sponsors
-              </p>
-            </div>
-          </div>
-        </template>
+        <gothamist-homepage-topper
+          :articles="[featuredArticle, ...latestArticles]"
+          :navigation="navigation"
+        />
         <!-- newsletter -->
         <div class="mt-8 mb-5">
           <hr class="black mb-4" />
@@ -213,6 +151,9 @@ onMounted(() => {
 </template>
 
 <style lang="scss">
+.page.index {
+  background: linear-gradient(180deg, #F3F3E4 0, rgba(255, 255, 255, 0) 615px, rgba(255, 255, 255, 0) 100%);
+}
 .v-card.featured-article {
   .card-details {
     padding: 0.75rem 0;


### PR DESCRIPTION
- Create main site header and add it to the default template
- Create sidebar
- Create default homepage topper / featured area as a component
- Refactor menu list to take any list of navigation links instead of just taking the whole navigation object and pulling out the footer links specifically
- A few CSS tweaks