### PR TITLE
ArticleRecirculation updates

### DIFF
--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -17,8 +17,11 @@ const props = defineProps({
 
 const route = useRoute()
 
+const routeSectionSlug = ref(route.params.routeSectionSlug || 'news')
+console.log('routeSectionSlug', routeSectionSlug.value)
+
 const { title: sectionTitle, id: sectionId } = await findPage(
-  route.params.sectionSlug as string
+  routeSectionSlug.value as string
 ).then(({ data }) => normalizeFindPageResponse(data))
 
 const articles = await findArticlePages({
@@ -170,6 +173,7 @@ onBeforeUnmount(() => {
 <style lang="scss">
 .recirculation {
   .v-card {
+    background: transparent;
     &.article-sm {
       .card-title-link .h2 {
         font-weight: 600 !important;

--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -117,7 +117,7 @@ onBeforeUnmount(() => {
           <v-card
             class="flex xl:hidden article-md mod-horizontal mod-left tag-small mb-5"
             :image="useImageUrl(articleMd.listingImage)"
-            :title="articleMd.title"
+            :title="articleMd.listingTitle || articleMd.title"
             :titleLink="articleMd.link"
             :width="318"
             :height="212"

--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -13,13 +13,16 @@ const props = defineProps({
     type: Object,
     default: {},
   },
+  slug: {
+    type: String,
+    default: null,
+  },
 })
 
 const route = useRoute()
-
-const routeSectionSlug = ref(route.params.routeSectionSlug || 'news')
-console.log('routeSectionSlug', routeSectionSlug.value)
-
+const routeSectionSlug = ref(
+  props.slug ? props.slug : route.params.sectionSlug || 'news'
+)
 const { title: sectionTitle, id: sectionId } = await findPage(
   routeSectionSlug.value as string
 ).then(({ data }) => normalizeFindPageResponse(data))

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,7 +48,6 @@ onMounted(() => {
   <div>
     <section>
       <div class="content">
-        <article-recirculation />
         <gothamist-homepage-topper
           :articles="[featuredArticle, ...latestArticles]"
           :navigation="navigation"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,6 +48,7 @@ onMounted(() => {
   <div>
     <section>
       <div class="content">
+        <article-recirculation />
         <gothamist-homepage-topper
           :articles="[featuredArticle, ...latestArticles]"
           :navigation="navigation"


### PR DESCRIPTION
articleRecirculation now defaults to `news` when route.params.sectionSlug is not present, and can be overwritten by a new prop called `slug`, where you can pass in any slug. So we can use this anywhere now. Also added transparency background into the instances of v-card in the ArticleRecirculation 