### PR TITLE
Create ads.txt for new site

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,451 @@
+#Google AdExchange
+google.com, pub-6728307037029826, RESELLER, f08c47fec0942fa0
+
+#Amazon UAM
+aps.amazon.com,30787d05-7895-471e-9cdf-d931d7b5ea5d,DIRECT
+pubmatic.com,160006,RESELLER,5d62403b186f2ace
+pubmatic.com,160096,RESELLER,5d62403b186f2ace
+rubiconproject.com,18020,RESELLER,0bfd66d529a55807
+pubmatic.com,157150,RESELLER,5d62403b186f2ace
+openx.com,540191398,RESELLER,6a698e2ec38604c6
+appnexus.com,1908,RESELLER,f5ab79cb980f11d1
+smaato.com,1100044650,RESELLER,07bcf65f187117b4
+ad-generation.jp,12474,RESELLER,7f4ea9029ac04e53
+districtm.io,100962,RESELLER,3fd707be9c4527c3
+appnexus.com,3663,RESELLER,f5ab79cb980f11d1
+rhythmone.com,1654642120,RESELLER,a670c89d4a324e47
+yahoo.com,55029,RESELLER,e1a5b5b6e3255540
+gumgum.com,14141,RESELLER,ffdef49475d318a9
+admanmedia.com,726,RESELLER
+sharethrough.com,7144eb80,RESELLER,d53b998a7bd4ecd2
+emxdgt.com,2009,RESELLER,1e1d41537f7cad7f
+appnexus.com,1356,RESELLER,f5ab79cb980f11d1
+contextweb.com,562541,RESELLER,89ff185a4c4e857c
+smartadserver.com,4125,RESELLER,060d053dcf45cbf3
+themediagrid.com,JTQKMP,RESELLER,35d5010d7789b49d
+sovrn.com,375328,RESELLER,fafdf38b16bf6b2b
+lijit.com,375328,RESELLER,fafdf38b16bf6b2b
+beachfront.com,14804,RESELLER,e2541279e8e2ca4d
+improvedigital.com,2050,RESELLER
+mintegral.com,10043,RESELLER,0aeed750c80d6423
+sonobi.com,7f5fa520f8,RESELLER,d1a215d9eb5aee9e
+onetag.com,770a440e65869c2,RESELLER
+
+
+#AppNexus
+appnexus.com, 2398, RESELLER, f5ab79cb980f11d1
+
+#Rubicon
+rubiconproject.com, 13322, DIRECT, 0bfd66d529a55807
+
+#IndexExchange
+indexexchange.com, 184169, DIRECT
+
+#OpenX
+openx.com, 539087730, RESELLER, 6a698e2ec38604c6
+
+#Sovrn
+sovrn.com, 224799, DIRECT, fafdf38b16bf6b2b
+lijit.com, 224799, DIRECT, fafdf38b16bf6b2b
+lijit.com, 224799-eb, DIRECT, fafdf38b16bf6b2b
+gumgum.com, 11645, RESELLER, ffdef49475d318a9
+openx.com, 538959099, RESELLER, 6a698e2ec38604c6
+openx.com, 539924617, RESELLER, 6a698e2ec38604c6
+pubmatic.com, 137711, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156212, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156700, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 17960, RESELLER, 0bfd66d529a55807
+
+#Conversant
+conversantmedia.com, 41990, DIRECT, 03113cd04947736d
+appnexus.com, 4052, RESELLER
+openx.com, 540031703, RESELLER, 6a698e2ec38604c6
+contextweb.com, 561998, RESELLER, 89ff185a4c4e857c
+pubmatic.com, 158100, RESELLER, 5d62403b186f2ace
+yahoo.com,  55771, RESELLER, e1a5b5b6e3255540
+rubiconproject.com, 23644, RESELLER, 0bfd66d529a55807
+
+#AOL
+adtech.com, 9965, DIRECT
+coxmt.com, 2000067907202, RESELLER
+pubmatic.com, 156078, RESELLER, #banner
+pubmatic.com, 156377, RESELLER, 5d62403b186f2ace
+openx.com, 537143344, RESELLER, #banner
+indexexchange.com, 175407, RESELLER, 50b1c356f2c5c8fc
+
+#DistrictM
+DMX: districtm.io, 100463, RESELLER , 3fd707be9c4527c3
+DistrictM: appnexus.com, 1908, RESELLER, f5ab79cb980f11d1
+
+#TripleLift
+triplelift.com, 6969, DIRECT, 6c33edb13117fd86
+triplelift.com, 6971, DIRECT, 6c33edb13117fd86
+triplelift.com, 6970, DIRECT, 6c33edb13117fd86
+triplelift.com, 6968, DIRECT, 6c33edb13117fd86
+triplelift.com, 6901, DIRECT, 6c33edb13117fd86
+triplelift.com, 7097, DIRECT, 6c33edb13117fd86
+triplelift.com, 7098, DIRECT, 6c33edb13117fd86
+triplelift.com, 7261, DIRECT, 6c33edb13117fd86
+appnexus.com, 1314, RESELLER
+
+#ShareThrough
+sharethrough.com, 075e42d9, DIRECT, d53b998a7bd4ecd2
+indexexchange.com, 186046, RESELLER,
+spotxchange.com, 212457, RESELLER,
+spotx.tv, 212457, RESELLER,
+pubmatic.com, 156557, RESELLER,
+rubiconproject.com, 18694, RESELLER, 0bfd66d529a55807
+openx.com, 540274407, RESELLER, 6a698e2ec38604c6
+
+#BounceX
+indexexchange.com, 183753, RESELLER
+pubmatic.com, 156512, RESELLER
+behave.com, 1027, DIRECT
+
+#Undertone
+undertone.com, 3590, DIRECT,
+appnexus.com, 2234, RESELLER,
+openx.com, 537153564, RESELLER, 6a698e2ec38604c6
+
+#Consumable
+adtech.com, 10947, RESELLER
+aolcloud.net, 10947, RESELLER
+appnexus.com, 1356, RESELLER
+appnexus.com, 7556, RESELLER
+contextweb.com, 560653, RESELLER
+emxdgt.com, 20, RESELLER, 1e1d41537f7cad7f
+google.com, pub-6694481294649483, RESELLER
+indexexchange.com, 184914, RESELLER
+indexexchange.com, 186248, RESELLER, 50b1c356f2c5c8fc
+lijit.com, 248396, RESELLER, fafdf38b16bf6b2b
+openx.com, 537150004, RESELLER
+pubmatic.com, 156319, RESELLER
+sonobi.com, e55fb5d7c2, RESELLER
+sovrn.com, 248396, RESELLER, fafdf38b16bf6b2b
+google.com, pub-599520256353724, RESELLER, f08c47fec0942fa0
+indexexchange.com, 175407, RESELLER
+openx.com, 537120960, RESELLER
+openx.com, 537143344, RESELLER
+openx.com, 538959099, RESELLER
+openx.com, 83499, RESELLER
+pubmatic.com, 137711, RESELLER
+pubmatic.com, 156078, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156212, RESELLER
+pubmatic.com, 62483, RESELLER
+rubiconproject.com, 17632, RESELLER, 0bfd66d529a55807
+google.com, pub-968573444547681, RESELLER, f08c47fec0942fa0
+openx.com, 539699341, RESELLER, 6a698e2ec38604c6
+pubmatic.com, 156458, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156138, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 18890, RESELLER, 0bfd66d529a55807
+pubmatic.com, 157367, RESELLER
+coxmt.com, 2000067907202, RESELLER
+indexexchange.com, 187454, RESELLER
+consumable.com, 2000861, DIRECT
+
+#Outbrain
+outbrain.com, 00786c222f38d6700c313366f9572cf92e, DIRECT, #FR
+outbrain.com, 00a14a0db5315312c1bf4109f9f0784dec, DIRECT, #TT
+outbrain.com, 00293949d791a6af0b41a5e0026bc2a630, DIRECT, #DM
+appnexus.com, 7597, RESELLER, f5ab79cb980f11d1
+tremorhub.com, q017o-78mlk, RESELLER, 1a4e959a1b50034a #PremiumVideoDemandakaTelaria
+teads.tv, 15429, RESELLER, 15a9c44f6d26cbe1 #PremiumVideoDemand
+advertising.com, 26154, RESELLER, #Premiumvideodemand
+spotxchange.com, 225721, RESELLER, #Premiumvideodemand
+freewheel.tv, 741650, RESELLER, #Premiumvideodemand
+rubiconproject.com, 17130, RESELLER, #Premiumvideodemand
+lkqd.net, 450, RESELLER, #Premiumvideodemand
+openx.com, 540393169, RESELLER, #Premiumvideodemand
+spotx.tv, 238936, RESELLER, #Premiumvideodemand
+spotxchange.com, 238936, RESELLER, #PremiumVideoDemand
+advertising.com, 28038, RESELLER, #PremiumVideoDemand
+
+#Telaria
+telaria.com, d5ke0-09igv, RESELLER, 1a4e959a1b50034a
+tremorhub.com, d5ke0-09igv, RESELLER, 1a4e959a1b50034a
+
+#BeachFront
+beachfront.com, 9638, DIRECT, e2541279e8e2ca4d
+
+#Teads
+teads.tv, 13960, DIRECT, 15a9c44f6d26cbe1
+
+#Rubicon EBDA
+rubiconproject.com, 21022, DIRECT, 0bfd66d529a55807
+
+#OpenX EBDA
+openx.com, 540717748, DIRECT, 6a698e2ec38604c6
+
+#Next Millenium
+nextmillennium.io, 5534, DIRECT, 65bd090fa4a1e3d6
+liqwid.com, 2147483484, DIRECT, 26d4db6b04ea5182
+advertising.com, 22153, RESELLER
+adtech.com, 10861, RESELLER
+aolcloud.net, 10861, RESELLER
+openx.com, 537106719, RESELLER, 6a698e2ec38604c6
+contextweb.com, 561481, RESELLER
+indexexchange.com, 183071, RESELLER
+openx.com, 540605749, RESELLER, 6a698e2ec38604c6
+google.com, pub-7269238500499280, RESELLER, f08c47fec0942fa0
+gumgum.com, 13165, DIRECT, ffdef49475d318a9
+gumgum.com, 13615, RESELLER, ffdef49475d318a9
+districtm.io, 101200, DIRECT, 3fd707be9c4527c3
+appnexus.com, 1908, RESELLER, f5ab79cb980f11d1
+appnexus.com, 7944, RESELLER, f5ab79cb980f11d1
+rubiconproject.com, 17888, DIRECT, 0bfd66d529a55807
+rubiconproject.com, 19142, DIRECT, 0bfd66d529a55807
+openx.com, 540224251, RESELLER, 6a698e2ec38604c6
+openx.com, 540255321, RESELLER, 6a698e2ec38604c6
+openx.com, 540233824, RESELLER, 6a698e2ec38604c6
+openx.com, 540225743, RESELLER, 6a698e2ec38604c6
+indexexchange.com, 188029, DIRECT
+indexexchange.com, 188333, DIRECT
+aps.amazon.com, 79e40b05-e673-4b6c-85f9-79252a7f96a5, DIRECT
+pubmatic.com, 157150, RESELLER, 5d62403b186f2ace
+districtm.io, 100962, RESELLER
+openx.com, 540191398, RESELLER, 6a698e2ec38604c6
+yldbt.com, 5b522cc167f6b300b89dc6d3, RESELLER, cd184cb30abaabb5
+coxmt.com, 2000100000000, RESELLER
+pubmatic.com, 157689, RESELLER, 5d62403b186f2ace
+pubmatic.com, 157577, RESELLER, 5d62403b186f2ace
+undertone.com, 3757, DIRECT
+appnexus.com, 2234, RESELLER
+openx.com, 537153564, RESELLER, 6a698e2ec38604c6
+springserve.com, 743, DIRECT, a24eb641fc82e93d
+beachfront.com, 4969, RESELLER, e2541279e8e2ca4d
+advertising.com, 26282, RESELLER,
+appnexus.com, 9284, RESELLER, f5ab79cb980f11d1
+conversantmedia.com, 41868, DIRECT,
+video.unrulymedia.com, UNRX-PUB-79ae5563-e8e5-40d2-8446-b661c8e95d52, DIRECT
+indexexchange.com, 182257, RESELLER
+appnexus.com, 6849, RESELLER
+rubiconproject.com, 15268, RESELLER
+spotxchange.com, 250862, DIRECT, 7842df1d2fe2db34
+spotx.tv, 250862, DIRECT, 7842df1d2fe2db34
+teads.tv, 18141, DIRECT, 15a9c44f6d26cbe1
+rhythmone.com, 2059465938, DIRECT, a670c89d4a324e47
+rhythmone.com, 316817661, DIRECT, a670c89d4a324e47
+beachfront.com, 13150, DIRECT, e2541279e8e2ca4d
+smartadserver.com, 1827, RESELLER
+improvedigital.com, 335, RESELLER
+appnexus.com, 3538, RESELLER
+appnexus.com, 3539, RESELLER
+appnexus.com, 3540, RESELLER
+contextweb.com, 562019, RESELLER, 89ff185a4c4e857c
+openx.com, 540752851, RESELLER, 6a698e2ec38604c6
+appnexus.com, 7118, RESELLER
+spotx.tv, 108933, RESELLER, 7842df1d2fe2db34
+spotxchange.com, 108933, RESELLER, 7842df1d2fe2db34
+improvedigital.com, 185, RESELLER
+adform.com, 183, RESELLER
+freewheel.tv, 33081, RESELLER
+freewheel.tv, 33601, RESELLER
+google.com, pub-8172268348509349, RESELLER, f08c47fec0942fa0
+
+#HTL
+hashtag-labs.com, 5, DIRECT
+
+#Slimcut
+freeskreen.com, 407, DIRECT, fe119a6acfd19070
+tremorhub.com, xh7jb-tlxtj, DIRECT, 1a4e959a1b50034a
+indexexchange.com,184088,RESELLER,50b1c356f2c5c8fc
+quantum-advertising.com, 3247, RESELLER
+quantum-advertising.com, 3159, RESELLER
+quantum-advertising.com, 3198, RESELLER
+appnexus.com, 2579, RESELLER #native
+smartadserver.com, 1772, RESELLER
+advertising.com, 22118, RESELLER
+
+#P
+google.com, pub-5460989936279337, DIRECT, f08c47fec0942fa0
+rubiconproject.com, 13380, RESELLER, 0bfd66d529a55807
+indexexchange.com, 185073, RESELLER, 50b1c356f2c5c8fc
+openx.com, 537133236, RESELLER, 6a698e2ec38604c6
+google.com, pub-6650322601660058, RESELLER, f08c47fec0942fa0
+appnexus.com, 2797, DIRECT
+adtech.com, 10383, RESELLER
+aolcloud.net, 10383, RESELLER
+sovrn.com, 2870, RESELLER
+xapads.com, 1050, RESELLER
+districtm.io, 100812, DIRECT
+google.com, pub-3984282086350136, DIRECT, f08c47fec0942fa0
+rubiconproject.com, 13380, RESELLER, 0bfd66d529a55807
+indexexchange.com, 185073, RESELLER, 50b1c356f2c5c8fc
+openx.com, 537133236, RESELLER, 6a698e2ec38604c6
+google.com, pub-6650322601660058, RESELLER, f08c47fec0942fa0
+adtech.com, 10383, RESELLER
+aolcloud.net, 10383, RESELLER
+sovrn.com, 2870, RESELLER
+appnexus.com, 2797, DIRECT
+taboola.com,1100807,DIRECT,c228e6794e811952 #taboola
+spotx.tv,71451,RESELLER #taboola
+spotxchange.com, 71451, RESELLER #taboola
+advertising.com, 8603, RESELLER #taboola
+advertising.com, 3531, RESELLER #taboola
+pubmatic.com, 156307, RESELLER, 5d62403b186f2ace #taboola
+appnexus.com, 3364, RESELLER #taboola
+Indexexchange.com, 183756, RESELLER #taboola
+contextweb.com, 560382, RESELLER #taboola
+openx.com, 539154393, RESELLER #taboola
+tremorhub.com, z87wm, RESELLER, 1a4e959a1b50034a #taboola
+rubiconproject.com, 16698, RESELLER, 0bfd66d529a55807 #taboola
+fyber.com, ad9de41d28d494354b23133f26f83122, RESELLER #taboola
+fyber.com, 1a12a7e3f84fe560ccf95a3a73043abb, RESELLER #taboola
+adsnative.com, 267, DIRECT #polymorph
+getpolymorph.com, 267, DIRECT #polymorph
+thetimmedia.com, 318, DIRECT #Memevideo
+memevideoad.com, 318, DIRECT #Memevideo
+spotxchange.com,98033, RESELLER,7842df1d2fe2db34 #Memevideo
+freewheel.tv, 151177, RESELLER #Memevideo
+freewheel.tv, 414097, RESELLER #Memevideo
+Insticator.com,05a7b2ff-a627-45e8-bd6b-68f53e68c7bf,DIRECT #Insticator
+google.com,pub-7630961163643137,RESELLER,f08c47fec0942fa0 #Insticator
+districtm.io,100683,RESELLER #Insticator
+openx.com,537117488,RESELLER,6a698e2ec38604c6 #Insticator
+pubmatic.com,95054,RESELLER,5d62403b186f2ace #Insticator
+appnexus.com,1908,RESELLER #Insticator
+appnexus.com,3695,RESELLER #Insticator
+appnexus.com,1356,RESELLER,f5ab79cb980f11d1 #Insticator
+sonobi.com,e315a43aa9,RESELLER #Insticator
+rhythmone.com,136898039,RESELLER,a670c89d4a324e47 #Insticator
+EMXDGT.com,22,RESELLER,1e1d41537f7cad7f #Insticator
+rubiconproject.com,17062,DIRECT,0bfd66d529a55807 #Insticator
+contextweb.com,561664,RESELLER,89ff185a4c4e857c #Insticator
+rhythmone.com,1059622079,RESELLER #Insticator
+contextweb.com,560606,RESELLER #Insticator
+rubiconproject.com,17980,RESELLER,0bfd66d529a55807 #Insticator
+Rhythmone.com,527383184,RESELLER,a670c89d4a324e47 #Insticator
+openx.com,540105394,RESELLER,6a698e2ec38604c6 #Insticator
+pubmatic.com, 157119, RESELLER, 5d62403b186f2ace #Insticator
+33across.com,0010b00001rrPUnAAM,DIRECT,bbea06d9c4d2853c ##Insticator
+gumgum.com, 13344, DIRECT, ffdef49475d318a9 #Insticator
+Smartadserver.com,3262,RESELLER #Insticator
+appnexus.com, 9393, DIRECT #Insticator
+ssp.ynxs.io, 185, RESELLER #Insticator
+districtm.io, 100812, DIRECT #districtm
+
+#OpenWeb 08.10.2022
+spotim.market, sp_2jg7GZ6C, DIRECT, 077e5f709d15bdbb
+spotim.market, sp_AYL2022, DIRECT, 077e5f709d15bdbb
+google.com, pub-5616046187545019, RESELLER, f08c47fec0942fa0
+adtech.com, 11465, RESELLER, e1a5b5b6e3255540
+yahoo.com, 57253, RESELLER
+openx.com, 539466082, RESELLER, 6a698e2ec38604c6
+openx.com, 540362110, RESELLER, 6a698e2ec38604c6
+openx.com, 540634772, RESELLER, 6a698e2ec38604c6
+openx.com, 556895823, RESELLER, 6a698e2ec38604c6
+openx.com, 557894793, RESELLER, 6a698e2ec38604c6
+video.unrulymedia.com, 449400134, RESELLER
+video.unrulymedia.com, 915882568, RESELLER
+spotxchange.com, 211945, RESELLER, 7842df1d2fe2db34
+spotx.tv, 211945, RESELLER, 7842df1d2fe2db34
+rubiconproject.com, 17184, RESELLER, 0bfd66d529a55807
+rubiconproject.com, 18728, RESELLER, 0bfd66d529a55807
+appnexus.com, 6933, RESELLER, f5ab79cb980f11d1
+pubmatic.com, 156758, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156813, RESELLER, 5d62403b186f2ace
+pubmatic.com, 157679, RESELLER, 5d62403b186f2ace
+adyoulike.com, e5ae8cdbe88e1f889aae7ee0c672ca30, DIRECT
+freewheel.tv, 848385, RESELLER
+freewheel.tv, 848401, RESELLER
+adtelligent.com, 283366, RESELLER
+improvedigital.com, 1628, RESELLER
+gumgum.com, 13579, RESELLER, ffdef49475d318a9
+indexexchange.com, 189478, RESELLER, 50b1c356f2c5c8fc
+indexexchange.com, 189529, RESELLER, 50b1c356f2c5c8fc
+indexexchange.com, 190532, RESELLER, 50b1c356f2c5c8fc
+sovrn.com, 250745, RESELLER, fafdf38b16bf6b2b
+lijit.com, 250745, RESELLER, fafdf38b16bf6b2b
+lijit.com, 250745-eb, RESELLER, fafdf38b16bf6b2b
+freewheel.tv, 961937, RESELLER
+freewheel.tv, 961953, RESELLER
+telaria.com, p4dt2-jhelk, RESELLER, 1a4e959a1b50034a
+tremorhub.com, p4dt2-jhelk, RESELLER, 1a4e959a1b50034a
+Telaria.com, p4dt2-t1by7, RESELLER, 1a4e959a1b50034a
+Tremorhub.com, p4dt2-t1by7, RESELLER, 1a4e959a1b50034a
+indexexchange.com, 192077, RESELLER
+triplelift.com, 10504, DIRECT, 6c33edb13117fd86
+triplelift.com, 10504-EB, DIRECT, 6c33edb13117fd86
+conversantmedia.com, 100292, RESELLER, 03113cd04947736d
+aps.amazon.com, 9eaf46de-e1bd-41c9-8a11-f5862f62cd8e, DIRECT
+indexexchange.com, 198639, RESELLER, 50b1c356f2c5c8fc
+yahoo.com, 59682, RESELLER
+pubmatic.com, 161646, RESELLER, 5d62403b186f2ace
+smaato.com, 1100044650, RESELLER, 07bcf65f187117b4
+Sharethrough.com, 7144eb80, RESELLER, d53b998a7bd4ecd2
+yieldmo.com, 2719019867620450718, RESELLER
+pubmatic.com, 160006, RESELLER, 5d62403b186f2ace
+pubmatic.com, 160096, RESELLER, 5d62403b186f2ace
+amxrtb.com, 105199619, DIRECT
+appnexus.com, 12290, RESELLER, f5ab79cb980f11d1
+indexexchange.com, 191503, RESELLER, 50b1c356f2c5c8fc
+pubmatic.com, 158355, RESELLER, 5d62403b186f2ace
+onetag.com, 75a1922f904cc20, RESELLER
+onetag.com, 75a1922f904cc20-OB, RESELLER
+smartadserver.com, 4242, RESELLER
+smartadserver.com, 4071, RESELLER
+smartadserver.com, 4242-OB, RESELLER, 060d053dcf45cbf3
+nativo.com, 5740, DIRECT, 59521ca7cc5e9fee
+media.net, 8CUD7PNFB, RESELLER
+E-planning.net, ba654c8953073b24, RESELLER, c1ba615865ed87b2
+criteo.com, B-068833, RESELLER, 9fac4a4a87c2a44f
+themediagrid.com, PA8RET, RESELLER, 35d5010d7789b49d 
+contextweb.com, 560571, RESELLER, 89ff185a4c4e857c
+appnexus.com, 9733, RESELLER
+rubiconproject.com, 20736, RESELLER, 0bfd66d529a55807
+pubmatic.com, 160925, RESELLER, 5d62403b186f2ace
+
+#AMX
+amxrtb.com, 105199331, DIRECT
+appnexus.com, 12290, RESELLER, f5ab79cb980f11d1
+appnexus.com, 11786, RESELLER, f5ab79cb980f11d1
+yahoo.com, 49648, RESELLER
+indexexchange.com, 191503, RESELLER, 50b1c356f2c5c8fc
+lijit.com, 260380, RESELLER, fafdf38b16bf6b2b
+sovrn.com, 260380, RESELLER, fafdf38b16bf6b2b
+pubmatic.com, 158355 , RESELLER, 5d62403b186f2ace
+appnexus.com, 9393, RESELLER #Video #Display, f5ab79cb980f11d1
+appnexus.com, 11924, RESELLER, f5ab79cb980f11d1
+rubiconproject.com, 17960, RESELLER, 0bfd66d529a55807 
+pubmatic.com, 159885, DIRECT, 5d62403b186f2ace
+
+#Concert
+google.com, pub-5405132603504384, RESELLER, f08c47fec0942fa0
+concert.io, cbs-dc9ea3c559, DIRECT
+
+#HCO
+google.com, pub-7995104076770938, DIRECT, f08c47fec0942fa0
+indexexchange.com, 187924, DIRECT, 50b1c356f2c5c8fc
+openx.com, 540322758, DIRECT, 6a698e2ec38604c6
+pubmatic.com, 157102, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 18008, RESELLER, 0bfd66d529a55807
+sovrn.com, 247572, DIRECT, fafdf38b16bf6b2b
+lijit.com, 247572, DIRECT, fafdf38b16bf6b2b
+triplelift.com, 4777-EB, DIRECT, 6c33edb13117fd86
+rhythmone.com, 217819044, direct, a670c89d4a324e47
+video.unrulymedia.com, 217819044, direct
+media.net, 8CU5MY34U, DIRECT
+sharethrough.com, dd2c91e6, DIRECT, d53b998a7bd4ecd2
+appnexus.com, 8790, DIRECT, f5ab79cb980f11d1
+indexexchange.com, 189458, DIRECT, 50b1c356f2c5c8fc
+openx.com, 543833106, DIRECT, 6a698e2ec38604c6
+pubmatic.com, 157163, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 13894, RESELLER, 0bfd66d529a55807
+teads.tv, 22148, DIRECT, 15a9c44f6d26cbe1
+media.net, 8CU2410EL, DIRECT
+sovrn.com, 232757, RESELLER, fafdf38b16bf6b2b
+lijit.com, 232757, RESELLER, fafdf38b16bf6b2b
+aps.amazon.com, ea05d466-f785-4b9a-a030-6fdc6a39498f, DIRECT
+openx.com, 540191398, RESELLER, 6a698e2ec38604c6
+pubmatic.com, 157150, RESELLER, 5d62403b186f2ace
+districtm.io, 100962, RESELLER
+appnexus.com, 1908, RESELLER, f5ab79cb980f11d1
+rubiconproject.com, 18020, RESELLER, 0bfd66d529a55807
+rhythmone.com, 1654642120, RESELLER, a670c89d4a324e47
+adtech.com, 12068, RESELLER, e1a5b5b6e3255540
+indexexchange.com, 194359, DIRECT, 50b1c356f2c5c8fc
+pubmatic.com, 160308, DIRECT, 5d62403b186f2ace
+
+hcodemedia.com, 409, DIRECT
+
+google.com, pub-9835879021808285, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Most recent ads.txt file per ad ops. This version introduces a new section for OpenWeb and removes the block for Disqus.