### PR TITLE
Setup display ads

### DIFF
--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -9,7 +9,6 @@ const props = defineProps({
 })
 
 const { $analytics } = useNuxtApp()
-const sensitiveContent = useSensitiveContent()
 const tags = ref(props.article.tags)
 const isSponsored = ref(props.article?.sponsoredContent || false)
 const isDisableComments = ref(props.article?.disableComments || false)
@@ -43,7 +42,7 @@ const onTagClicked = (tag) => {
           class="mb-4 md:mb-6"
         />
         <div class="block mx-auto block lg:hidden mb-6" style="width: 300px">
-          <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_2" />
+          <HtlAd layout="rectangle" slot="gothamist_interior_rectangle_article_bio" />
           <p class="type-fineprint">
             Gothamist is funded by sponsors and member donations
           </p>
@@ -54,7 +53,7 @@ const onTagClicked = (tag) => {
         </div>
       </div>
       <div class="col-fixed mx-auto hidden lg:block">
-        <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_3" />
+        <HtlAd layout="rectangle" slot="gothamist_interior_rectangle_article_bio" />
         <p class="type-fineprint">
           Gothamist is funded by sponsors and member donations
         </p>

--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -9,6 +9,7 @@ const props = defineProps({
 })
 
 const { $analytics } = useNuxtApp()
+const sensitiveContent = useSensitiveContent()
 const tags = ref(props.article.tags)
 const isSponsored = ref(props.article?.sponsoredContent || false)
 const isDisableComments = ref(props.article?.disableComments || false)
@@ -42,14 +43,7 @@ const onTagClicked = (tag) => {
           class="mb-4 md:mb-6"
         />
         <div class="block mx-auto block lg:hidden mb-6" style="width: 300px">
-          <!-- <div class="htlad-index_rectangle_1" /> -->
-          <img
-            src="https://fakeimg.pl/300x250/?text=AD Here"
-            style="width: 100%; max-width: 300px"
-            width="300"
-            height="250"
-            alt="advertisement"
-          />
+          <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_2" />
           <p class="type-fineprint">
             Gothamist is funded by sponsors and member donations
           </p>
@@ -60,14 +54,7 @@ const onTagClicked = (tag) => {
         </div>
       </div>
       <div class="col-fixed mx-auto hidden lg:block">
-        <!-- <div class="htlad-index_rectangle_1" /> -->
-        <img
-          src="https://fakeimg.pl/300x250/?text=AD Here"
-          style="width: 100%; max-width: 300px"
-          width="300"
-          height="250"
-          alt="advertisement"
-        />
+        <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_3" />
         <p class="type-fineprint">
           Gothamist is funded by sponsors and member donations
         </p>

--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -42,10 +42,11 @@ const onTagClicked = (tag) => {
           class="mb-4 md:mb-6"
         />
         <div class="block mx-auto block lg:hidden mb-6" style="width: 300px">
-          <HtlAd layout="rectangle" slot="gothamist_interior_rectangle_article_bio" />
-          <p class="type-fineprint">
-            Gothamist is funded by sponsors and member donations
-          </p>
+          <HtlAd
+            layout="rectangle"
+            slot="gothamist_interior_rectangle_article_bio"
+            fineprint="Gothamist is funded by sponsors and member donations"
+          />
         </div>
         <div v-if="!isDisableComments" id="comments" class="mb-4 md:mb-6">
           <hr class="black mb-4 md:mb-6" />
@@ -53,10 +54,11 @@ const onTagClicked = (tag) => {
         </div>
       </div>
       <div class="col-fixed mx-auto hidden lg:block">
-        <HtlAd layout="rectangle" slot="gothamist_interior_rectangle_article_bio" />
-        <p class="type-fineprint">
-          Gothamist is funded by sponsors and member donations
-        </p>
+        <HtlAd
+          layout="rectangle"
+          slot="gothamist_interior_rectangle_article_bio"
+          fineprint="Gothamist is funded by sponsors and member donations"
+        />
       </div>
     </div>
   </div>

--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -44,7 +44,7 @@ const onTagClicked = (tag) => {
         <div class="block mx-auto block lg:hidden mb-6" style="width: 300px">
           <HtlAd
             layout="rectangle"
-            slot="gothamist_interior_rectangle_article_bio"
+            slot="htlad-gothamist_interior_rectangle_article_bio"
             fineprint="Gothamist is funded by sponsors and member donations"
           />
         </div>
@@ -56,7 +56,7 @@ const onTagClicked = (tag) => {
       <div class="col-fixed mx-auto hidden lg:block">
         <HtlAd
           layout="rectangle"
-          slot="gothamist_interior_rectangle_article_bio"
+          slot="htlad-gothamist_interior_rectangle_article_bio"
           fineprint="Gothamist is funded by sponsors and member donations"
         />
       </div>

--- a/components/CenterFeature.vue
+++ b/components/CenterFeature.vue
@@ -130,8 +130,8 @@ const articlesSm = ref([
             />
           </v-card>
         </horizontal-drag>
-        <HtlAd layout="rectangle" slot="htlad-gothamist_index_midpage_1"/>
       </div>
+      <HtlAd layout="rectangle" slot="htlad-gothamist_index_midpage_1"/>
     </div>
   </div>
 </template>

--- a/components/CenterFeature.vue
+++ b/components/CenterFeature.vue
@@ -23,10 +23,6 @@ const articlesSm = ref([
 
 <template>
   <div v-if="articleLg && articleMd && articlesSm" class="center-feature">
-    <template v-if="collection.label">
-      <hr class="mb-2 black" />
-      <div class="type-label3 mb-5">{{ collection.label }}</div>
-    </template>
     <div class="grid gutter-x-30">
       <div class="col-fixed flex-order-2 lg:flex-order-1">
         <!-- md article desktop  -->
@@ -78,7 +74,12 @@ const articlesSm = ref([
           </p>
           <v-card-metadata :article="articleMd" />
         </v-card>
-        <HtlAd layout="rectangle" slot="htlad-gothamist_index_midpage_1"/>
+        <div class="hidden lg:block mb-4 xl:mb-7">
+          <HtlAd
+            layout="rectangle"
+            slot="htlad-gothamist_index_topper"
+          />
+        </div>
       </div>
       <div class="col flex-order-1 lg:flex-order-2">
         <v-card
@@ -130,8 +131,13 @@ const articlesSm = ref([
             />
           </v-card>
         </horizontal-drag>
+        <div class="block lg:hidden mb-4 xl:mb-7 m-auto mt-6">
+          <HtlAd
+            layout="rectangle"
+            slot="htlad-gothamist_index_topper"
+          />
+        </div>
       </div>
-      <HtlAd layout="rectangle" slot="htlad-gothamist_index_midpage_1"/>
     </div>
   </div>
 </template>

--- a/components/CenterFeature.vue
+++ b/components/CenterFeature.vue
@@ -74,13 +74,7 @@ const articlesSm = ref([
           </p>
           <v-card-metadata :article="articleMd" />
         </v-card>
-        <img
-          class="hidden lg:block mb-4 xl:mb-7"
-          src="https://fakeimg.pl/300x250/?text=AD Here"
-          width="300"
-          height="250"
-          alt="advertisement"
-        />
+        <HtlAd layout="rectangle" slot="htlad-gothamist_index_midpage_1"/>
       </div>
       <div class="col flex-order-1 lg:flex-order-2">
         <v-card
@@ -132,13 +126,7 @@ const articlesSm = ref([
             />
           </v-card>
         </horizontal-drag>
-        <img
-          class="block lg:hidden mb-4 xl:mb-7 m-auto mt-6"
-          src="https://fakeimg.pl/300x250/?text=AD Here"
-          width="300"
-          height="250"
-          alt="advertisement"
-        />
+        <HtlAd layout="rectangle" slot="htlad-gothamist_index_midpage_1"/>
       </div>
     </div>
   </div>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   articles: ArticlePage[]
   navigation: Navigation
 }>()
-
+const sensitiveContent = useSensitiveContent()
 const featuredArticle = computed(() => props.articles[0])
 const latestArticles = computed(() => props.articles.slice(1))
 </script>
@@ -70,14 +70,7 @@ const latestArticles = computed(() => props.articles.slice(1))
           <v-card-metadata :article="article" :showComments="false" />
         </v-card>
       </div>
-      <img
-        class="mb-1"
-        src="https://fakeimg.pl/450x250/?text=AD Here"
-        style="max-width: 100%"
-        width="450"
-        height="250"
-        alt="advertisement"
-      />
+      <div v-if="!sensitiveContent" class="htlad-gothamist_index_leaderboard_2"></div>
       <p class="type-fineprint">
         Gothamist is funded by sponsors and member donations
       </p>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -78,10 +78,11 @@ const latestArticles = computed(() => props.articles.slice(1))
         </v-card>
       </horizontal-drag>
       <div class="mb-1 mx-auto block">
-        <HtlAd slot="htlad-gothamist_index_topper" layout="rectangle" />
-        <p class="type-fineprint">
-          Gothamist is funded by sponsors and member donations
-        </p>
+        <HtlAd
+          slot="htlad-gothamist_index_topper"
+            layout="rectangle"
+            fineprint="Gothamist is funded by sponsors and member donations"
+          />
       </div>
     </div>
   </div>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -72,17 +72,13 @@ const latestArticles = computed(() => props.articles.slice(1))
           <v-card-metadata :article="article" :showComments="false" />
         </v-card>
       </div>
-      <img
-        class="mb-1"
-        src="https://fakeimg.pl/450x250/?text=AD Here"
-        style="max-width: 100%"
-        width="450"
-        height="250"
-        alt="advertisement"
-      />
-      <p class="type-fineprint">
-        Gothamist is funded by sponsors and member donations
-      </p>
+      <div class="mb-1">
+        <HtlAd
+        layout="rect"
+        slot="htlad-gothamist_index_topper"
+        fineprint="Gothamist is funded by sponsors and member donations"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -9,7 +9,6 @@ const props = defineProps<{
   articles: ArticlePage[]
   navigation: Navigation
 }>()
-const sensitiveContent = useSensitiveContent()
 const featuredArticle = computed(() => props.articles[0])
 const latestArticles = computed(() => props.articles.slice(1))
 </script>
@@ -70,7 +69,7 @@ const latestArticles = computed(() => props.articles.slice(1))
           <v-card-metadata :article="article" :showComments="false" />
         </v-card>
       </div>
-      <div v-if="!sensitiveContent" class="htlad-gothamist_index_topper"></div>
+      <HtlAd slot="htlad-gothamist_index_topper" layout="rectangle" />
       <p class="type-fineprint">
         Gothamist is funded by sponsors and member donations
       </p>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -74,7 +74,7 @@ const latestArticles = computed(() => props.articles.slice(1))
       </div>
       <div class="mb-1">
         <HtlAd
-        layout="rect"
+        layout="rectangle"
         slot="htlad-gothamist_index_topper"
         fineprint="Gothamist is funded by sponsors and member donations"
         />

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -70,7 +70,7 @@ const latestArticles = computed(() => props.articles.slice(1))
           <v-card-metadata :article="article" :showComments="false" />
         </v-card>
       </div>
-      <div v-if="!sensitiveContent" class="htlad-gothamist_index_leaderboard_2"></div>
+      <div v-if="!sensitiveContent" class="htlad-gothamist_index_topper"></div>
       <p class="type-fineprint">
         Gothamist is funded by sponsors and member donations
       </p>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
   articles: ArticlePage[]
   navigation: Navigation
 }>()
+
 const featuredArticle = computed(() => props.articles[0])
 const latestArticles = computed(() => props.articles.slice(1))
 </script>
@@ -54,36 +55,34 @@ const latestArticles = computed(() => props.articles.slice(1))
           label="LATEST"
         />
       </v-flexible-link>
-
-      <horizontal-drag
-        :articles="latestArticles"
-        v-slot="slotProps"
-        class="mb-4"
-      >
+      <div v-for="(article, index) in latestArticles" :key="article.uuid">
         <v-card
-          class="mod-horizontal mod-left mod-small mb-0"
-          :image="useImageUrl(slotProps.article.listingImage)"
-          :width="106"
+          :id="index === 3 ? 'ntv-latest-1' : ''"
+          class="mod-horizontal mod-left mod-small mb-3 tag-small"
+          :image="useImageUrl(article.listingImage)"
+          :width="158"
           :height="106"
-          :ratio="[1, 1]"
-          :sizes="[2]"
-          :title="slotProps.article.listingTitle || slotProps.article.title"
-          :titleLink="slotProps.article.link"
-          :maxWidth="slotProps.article.listingImage?.width"
-          :maxHeight="slotProps.article.listingImage?.height"
+          :sizes="[1]"
+          :title="article.listingTitle || article.title"
+          :titleLink="article.link"
+          :maxWidth="article.listingImage?.width"
+          :maxHeight="article.listingImage?.height"
           :quality="80"
         >
-          <div></div>
-          <v-card-metadata :article="slotProps.article" :showComments="false" />
+          <v-card-metadata :article="article" :showComments="false" />
         </v-card>
-      </horizontal-drag>
-      <div class="mb-1 mx-auto block">
-        <HtlAd
-          slot="htlad-gothamist_index_topper"
-            layout="rectangle"
-            fineprint="Gothamist is funded by sponsors and member donations"
-          />
       </div>
+      <img
+        class="mb-1"
+        src="https://fakeimg.pl/450x250/?text=AD Here"
+        style="max-width: 100%"
+        width="450"
+        height="250"
+        alt="advertisement"
+      />
+      <p class="type-fineprint">
+        Gothamist is funded by sponsors and member donations
+      </p>
     </div>
   </div>
 </template>
@@ -98,11 +97,5 @@ const latestArticles = computed(() => props.articles.slice(1))
 
 .homepage-topper-logo {
   height: auto;
-}
-
-.v-card.featured-article {
-  .card-details {
-    padding: 0.75rem 0;
-  }
 }
 </style>

--- a/components/HtlAd.vue
+++ b/components/HtlAd.vue
@@ -2,6 +2,7 @@
 defineProps<{
     slot: string
     layout: string
+    fineprint?: string
 }>()
 
 const sensitiveContent = useSensitiveContent()
@@ -10,6 +11,7 @@ const sensitiveContent = useSensitiveContent()
 <template>
 <div :class="`ad-wrapper ${sensitiveContent ? '' : layout}`">
     <div v-if="!sensitiveContent" :class="slot"></div>
+    <p v-if="fineprint && !sensitiveContent" class="type-fineprint">{{fineprint}}</p>
 </div>
 
 </template>

--- a/components/HtlAd.vue
+++ b/components/HtlAd.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+defineProps<{
+    slot: string
+    layout: string
+}>()
+
+const sensitiveContent = useSensitiveContent()
+</script>
+
+<template>
+<div :class="`ad-wrapper ${layout}`">
+    <div v-if="sensitiveContent" :class="slot"></div>
+</div>
+
+</template>
+<style lang="scss">
+.ad-wrapper.leaderboard {
+    min-width: 300px;
+    min-height: 50px;
+    @include media('>sm') {
+        min-width: 728px;
+        min-height: 90px;
+    }
+}
+
+.ad-wrapper.wide {
+    min-width: 300px;
+    min-height: 250px;
+    @include media('>sm') {
+        min-width: 728px;
+        min-height: 90px;
+    }
+}
+
+.ad-wrapper.rectangle {
+    min-width: 300px;
+    min-height: 250px;
+}
+
+</style>

--- a/components/HtlAd.vue
+++ b/components/HtlAd.vue
@@ -8,8 +8,8 @@ const sensitiveContent = useSensitiveContent()
 </script>
 
 <template>
-<div :class="`ad-wrapper ${layout}`">
-    <div v-if="sensitiveContent" :class="slot"></div>
+<div :class="`ad-wrapper ${sensitiveContent ? '' : layout}`">
+    <div v-if="!sensitiveContent" :class="slot"></div>
 </div>
 
 </template>

--- a/components/Streamfield/StreamfieldParagraph.vue
+++ b/components/Streamfield/StreamfieldParagraph.vue
@@ -6,5 +6,5 @@ defineProps<{
 </script>
 
 <template>
-  <div class="streamfield-paragraph mb-5" v-html="block.value" />
+  <div class="streamfield-paragraph rte-text mb-5" v-html="block.value" />
 </template>

--- a/composables/dom.js
+++ b/composables/dom.js
@@ -2,7 +2,7 @@
 // const HEADER_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5']
 const EMBED_TAGS = ['iframe', 'embed', 'video',
   'twitter-widget', 'center', 'div']
-const TEXT_CLASS = 'o-rte-text'
+const TEXT_CLASS = 'rte-text'
 // a `div` tag in MT article markup is probably from an embed
 const EMBED_WEIGHT = 50
 

--- a/error.vue
+++ b/error.vue
@@ -156,7 +156,7 @@ const newsletterSubmitEvent = () => {
           <div class="error-page-error pt-2">
             {{ error.statusCode }} Error - {{ error.statusMessage }}
           </div>
-          <div v-if="$config.DEBUG === 'true'" class="mt-4">
+          <div v-if="config.DEBUG === 'true'" class="mt-4">
             <pre class="font-bold">{{ error.message }}</pre>
             <div v-html="error.description"></div>
           </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -95,7 +95,7 @@ watch(route, (value) => {
     </Html>
     <div v-if="!sensitiveContent" class="htlad-skin" />
     <div class="leaderboard-ad-wrapper flex justify-content-center">
-      <div v-if="!sensitiveContent" class='htlad-index_leaderboard_1'></div>
+      <div v-if="!sensitiveContent" :class="`htlad-gothamist_${route.name === 'index' ? 'index' : 'interior'}_leaderboard_1`"></div>
     </div>
     <GothamistMainHeader 
       :navigation="navigation"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -103,7 +103,11 @@ watch(route, (value) => {
     </Html>
     <div v-if="!sensitiveContent" class="htlad-skin" />
     <div class="leaderboard-ad-wrapper flex justify-content-center">
-      <HtlAd layout="leaderboard" :slot="`htlad-gothamist_${route.name === 'index' ? 'index' : 'interior'}_leaderboard_1`" />
+      <HtlAd
+        layout="leaderboard"
+        :key="route.name"
+        :slot="`htlad-gothamist_${route.name === 'index' ? 'index' : 'interior'}_leaderboard_1`"
+      />
     </div>
     <GothamistMainHeader 
       :navigation="navigation"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -95,7 +95,7 @@ watch(route, (value) => {
     </Html>
     <div v-if="!sensitiveContent" class="htlad-skin" />
     <div class="leaderboard-ad-wrapper flex justify-content-center">
-      <div v-if="!sensitiveContent" :class="`htlad-gothamist_${route.name === 'index' ? 'index' : 'interior'}_leaderboard_1`"></div>
+      <HtlAd layout="leaderboard" :slot="`htlad-gothamist_${route.name === 'index' ? 'index' : 'interior'}_leaderboard_1`" />
     </div>
     <GothamistMainHeader 
       :navigation="navigation"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -73,8 +73,8 @@ export default defineNuxtConfig({
   publicRuntimeConfig: {
     SENTRY_DSN: process.env['SENTRY_DSN'] || 'https://531d9ce2b7a14759a35f95f3dd1ee743@o557978.ingest.sentry.io/6537168',
     SENTRY_ENV: process.env['SENTRY_ENV'] || 'development',
-    HTL_CSS: process.env['HTL_CSS'] || 'https://htlbid.com/stage/v3/gothamist.com/htlbid.css',
-    HTL_JS: process.env['HTL_JS'] || 'https://htlbid.com/stage/v3/gothamist.com/htlbid.js',
+    HTL_CSS: process.env['HTL_CSS'] || 'https://htlbid.com/stage/v3/gothamistv3.com/htlbid.css',
+    HTL_JS: process.env['HTL_JS'] || 'https://htlbid.com/stage/v3/gothamistv3.com/htlbid.js',
     HTL_IS_TESTING: process.env['HTL_IS_TESTING'] || 'yes',
     API_URL: process.env['API_URL'] || 'https://cms.demo.nypr.digital/api/v2',
     IMAGE_BASE_URL: process.env['IMAGE_BASE_URL'] || 'https://cms.demo.nypr.digital/images/',

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -52,9 +52,12 @@ onUnmounted(() => {
 
 // handle ads when the article is mounted
 function handleArticleMounted(el) {
-  const landmarks = useStreamfieldLandmarks(el.value)
-  const adTarget = landmarks[Math.min(landmarks.length - 1, 5)].node
-  useInsertAd(adTarget)
+  let landmarks = useStreamfieldLandmarks(el.value)
+  do {
+    const adTarget = landmarks[Math.min(landmarks.length - 1, 5)].node
+    useInsertAd(adTarget)
+    landmarks = landmarks.slice(6)
+  } while (landmarks.length > 6)
 }
 
 // insert ads into the target element
@@ -63,10 +66,7 @@ function useInsertAd(targetElement) {
   if (article && !sensitiveContent.value) {
     const adDiv = document.createElement('DIV')
     adDiv.classList.add(
-      'gothamist_interior_midpage_repeating',
-      'ad-div',
-      'mod-break-margins',
-      'mod-ad-disclosure',
+      'htlad-gothamist_interior_midpage_repeating',
       'mb-5'
     )
     useInsertAfterElement(adDiv, targetElement)

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -62,8 +62,7 @@ function handleArticleMounted(el) {
 
 // insert ads into the target element
 function useInsertAd(targetElement) {
-  const sensitiveContent = useSensitiveContent()
-  if (article && !sensitiveContent.value) {
+  if (article && !article.sensitiveContent) {
     const adDiv = document.createElement('DIV')
     adDiv.classList.add(
       'htlad-gothamist_interior_midpage_repeating',
@@ -183,10 +182,10 @@ const getGalleryLink = computed(() => {
             />
           </div>
           <div class="col-fixed hidden lg:block">
-            <HtlAd layout="rectangle" slot="gothamist_interior_rectangle_topper" />
-            <p class="type-fineprint">
-              Gothamist is funded by sponsors and member donations
-            </p>
+            <HtlAd
+              layout="rectangle"
+              slot="gothamist_interior_rectangle_topper"
+              fineprint="Gothamist is funded by sponsors and member donations"/>
           </div>
         </div>
       </div>

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -184,7 +184,7 @@ const getGalleryLink = computed(() => {
           <div class="col-fixed hidden lg:block">
             <HtlAd
               layout="rectangle"
-              slot="gothamist_interior_rectangle_topper"
+              slot="htlad-gothamist_interior_rectangle_topper"
               fineprint="Gothamist is funded by sponsors and member donations"/>
           </div>
         </div>

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -63,7 +63,7 @@ function useInsertAd(targetElement) {
   if (article && !sensitiveContent.value) {
     const adDiv = document.createElement('DIV')
     adDiv.classList.add(
-      'htlad-interior_midpage_1',
+      'gothamist_interior_midpage_repeating',
       'ad-div',
       'mod-break-margins',
       'mod-ad-disclosure',
@@ -183,14 +183,7 @@ const getGalleryLink = computed(() => {
             />
           </div>
           <div class="col-fixed hidden lg:block">
-            <!-- <div class="htlad-index_rectangle_1" /> -->
-            <img
-              src="https://fakeimg.pl/300x250/?text=AD Here"
-              style="width: 100%; max-width: 300px"
-              width="300"
-              height="250"
-              alt="advertisement"
-            />
+            <HtlAd layout="rectangle" slot="gothamist_interior_rectangle_topper" />
             <p class="type-fineprint">
               Gothamist is funded by sponsors and member donations
             </p>

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -2,6 +2,7 @@
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 
 const route = useRoute()
+const sensitiveContent = useSensitiveContent()
 
 const { title: sectionTitle, id: sectionId } = await findPage(
   route.params.sectionSlug as string
@@ -75,11 +76,7 @@ const newsletterSubmitEvent = () => {
           </div>
 
           <div class="col-fixed mx-auto">
-            <img
-              class="mb-4 xl:mb-7"
-              src="https://fakeimg.pl/300x600/?text=AD Here"
-              style="max-width: 100%"
-            />
+            <div v-if="!sensitiveContent" class="htl-gothamist_interior_midpage_1"></div>
           </div>
         </div>
         <!-- newsletter -->

--- a/pages/[sectionSlug]/photos/[gallerySlug].vue
+++ b/pages/[sectionSlug]/photos/[gallerySlug].vue
@@ -126,15 +126,6 @@ onUnmounted(() => {
           :class="{ 'xl:col-6': index % 3 !== 0 }"
           :key="index"
         >
-          <template v-if="index % 3 === 0 && index !== 0">
-            <img
-              class="mb-4 xl:mb-7"
-              src="https://fakeimg.pl/300x250/?text=AD Here"
-              width="300"
-              height="250"
-              alt="advertisement"
-            />
-          </template>
           <v-image-with-caption
             v-if="slide.image"
             :image="useImageUrl(slide.image)"
@@ -151,6 +142,10 @@ onUnmounted(() => {
             :allow-preview="true"
           />
           <hr class="mt-4 xl:mt-4 mb-2 xl:mb-4" />
+          <template v-if="index == 2 || index % 6 === 0">
+            <HtlAd layout="rectangle" slot="htlad-gothamist_interior_midpage_repeating" />
+            <hr class="mt-4 xl:mt-4 mb-2 xl:mb-4" />
+          </template>
         </div>
       </div>
       <div class="text-right mt-2">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,6 +2,9 @@
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import useImageUrl from '~~/composables/useImageUrl'
 
+
+const sensitiveContent = useSensitiveContent()
+
 // the home page featured article should display only the first story in the home page content collection
 const featuredArticle = await findPage('/').then(({ data }) =>
   normalizeArticlePage(data.value.pageCollectionRelationship?.[0].pages?.[0])
@@ -130,14 +133,7 @@ onMounted(() => {
               </Button>
             </div>
             <div class="col-fixed hidden xl:block mx-auto">
-              <img
-                class="mb-4 xl:mb-7"
-                src="https://fakeimg.pl/300x600/?text=AD Here"
-                style="max-width: 100%"
-                width="300"
-                height="600"
-                alt="advertisement"
-              />
+              <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_1"></div>
             </div>
           </div>
         </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,9 +2,6 @@
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import useImageUrl from '~~/composables/useImageUrl'
 
-
-const sensitiveContent = useSensitiveContent()
-
 // the home page featured article should display only the first story in the home page content collection
 const featuredArticle = await findPage('/').then(({ data }) =>
   normalizeArticlePage(data.value.pageCollectionRelationship?.[0].pages?.[0])
@@ -18,7 +15,10 @@ const articles = await findArticlePages('').then(({ data }) =>
   normalizeFindArticlePagesResponse(data)
 )
 
-const articlesToShow = ref(6)
+const riverStoryCount = ref(6)
+const riverAdOffset = ref(2)
+const riverAdRepeatRate = ref(6)
+
 
 const homePageCollections = []
 const homePageCollectionItems = await findPage('/').then(({ data }) =>
@@ -96,7 +96,7 @@ onMounted(() => {
             <div class="col-12 xxl:col-1 type-label3">LATEST</div>
             <div class="col">
               <div
-                v-for="article in articles.slice(0, articlesToShow)"
+                v-for="(article, index) in articles.slice(0, riverStoryCount)"
                 :key="article.uuid"
               >
                 <v-card
@@ -123,17 +123,21 @@ onMounted(() => {
                   <v-card-metadata :article="article" />
                 </v-card>
                 <hr class="mb-5" />
+                <div v-if="(index + riverAdOffset) % riverAdRepeatRate === 0" class="xl:hidden">
+                  <HtlAd slot="htlad-gothamist_index_river" layout="rectangle" />
+                  <hr class="mb-5" />
+                </div>
               </div>
               <Button
-                v-if="articlesToShow < articles.length"
+                v-if="riverStoryCount < articles.length"
                 class="p-button-rounded"
                 label="Load More"
-                @click="articlesToShow += 6"
+                @click="riverStoryCount += 6"
               >
               </Button>
             </div>
             <div class="col-fixed hidden xl:block mx-auto">
-              <div v-if="!sensitiveContent" class="htlad-gothamist_index_river"></div>
+                  <HtlAd slot="htlad-gothamist_index_river" layout="rectangle" />
             </div>
           </div>
         </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -133,7 +133,7 @@ onMounted(() => {
               </Button>
             </div>
             <div class="col-fixed hidden xl:block mx-auto">
-              <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_1"></div>
+              <div v-if="!sensitiveContent" class="htlad-gothamist_index_river"></div>
             </div>
           </div>
         </template>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -124,7 +124,7 @@ const newsletterSubmitEvent = () => {
                 </Button>
               </div>
               <div class="col-fixed hidden xl:block mx-auto">
-                <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_repeating" />
+                <div v-if="!sensitiveContent" class="htlad-gothamist_interior_midpage_repeating" />
               </div>
             </div>
           </template>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -8,6 +8,7 @@ const route = useRoute()
 const { $analytics } = useNuxtApp()
 const querySlug = route.query.q
 const query = ref(querySlug || '')
+const sensitiveContent = useSensitiveContent()
 
 let articles = ref(
   await searchArticlePages({ q: querySlug }).then(({ data }) =>
@@ -123,14 +124,7 @@ const newsletterSubmitEvent = () => {
                 </Button>
               </div>
               <div class="col-fixed hidden xl:block mx-auto">
-                <img
-                  class="mb-4 xl:mb-7"
-                  src="https://fakeimg.pl/300x600/?text=AD Here"
-                  style="max-width: 100%"
-                  width="300"
-                  height="600"
-                  alt="advertisement"
-                />
+                <div v-if="!sensitiveContent" class="htlad-gothamist_index_midpage_repeating" />
               </div>
             </div>
           </template>

--- a/pages/staff/[staffSlug].vue
+++ b/pages/staff/[staffSlug].vue
@@ -105,27 +105,14 @@ onUnmounted(() => {
           </div>
           <p v-else class="col">No articles available</p>
           <div class="col-fixed col-fixed-width-330 hidden xl:block">
-            <img
-              src="https://fakeimg.pl/300x600/?text=AD Here"
-              style="width: 100%; max-width: 300px"
-              width="300"
-              height="600"
-              alt="advertisement"
-            />
+            <HtlAd layout="rectangle" slot="htl-gothamist_interior_midpage_1" />
             <p class="type-fineprint">
               Gothamist is funded by sponsors and member donations
             </p>
           </div>
         </div>
         <div class="block xl:hidden mb-4">
-          <img
-            src="https://fakeimg.pl/300x250/?text=AD Here"
-            class="block m-auto"
-            style="width: 100%; max-width: 300px"
-            width="300"
-            height="250"
-            alt="advertisement"
-          />
+          <HtlAd layout="rectangle" slot="htl-gothamist_interior_midpage_2" />
           <p class="type-fineprint text-center">
             Gothamist is funded by sponsors and member donations
           </p>

--- a/pages/staff/[staffSlug].vue
+++ b/pages/staff/[staffSlug].vue
@@ -105,17 +105,19 @@ onUnmounted(() => {
           </div>
           <p v-else class="col">No articles available</p>
           <div class="col-fixed col-fixed-width-330 hidden xl:block">
-            <HtlAd layout="rectangle" slot="htl-gothamist_interior_midpage_1" />
-            <p class="type-fineprint">
-              Gothamist is funded by sponsors and member donations
-            </p>
+            <HtlAd
+              layout="rectangle"
+              slot="htl-gothamist_interior_midpage_1"
+              fineprint="Gothamist is funded by sponsors and member donations"
+            />
           </div>
         </div>
         <div class="block xl:hidden mb-4">
-          <HtlAd layout="rectangle" slot="htl-gothamist_interior_midpage_2" />
-          <p class="type-fineprint text-center">
-            Gothamist is funded by sponsors and member donations
-          </p>
+          <HtlAd
+            layout="rectangle"
+            slot="htl-gothamist_interior_midpage_2"
+            fineprint="Gothamist is funded by sponsors and member donations"
+          />
         </div>
         <Button
           v-if="articles && articlesToShow < articles.length"

--- a/pages/tags/[tagSlug].vue
+++ b/pages/tags/[tagSlug].vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { TagPage } from '../../composables/types/Page'
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
-import VByline from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VByline.vue'
 import VImageWithCaption from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VImageWithCaption.vue'
 
 const { $analytics, $htlbid } = useNuxtApp()
@@ -64,6 +63,7 @@ const newsletterSubmitEvent = () => {
           :streamfield-blocks="curatedTagPage.topPageZone"
           class="pt-4 lg:pt-6"
         />
+        <HtlAd layout="rectangle" slot="htlad-gothamist_interior_midpage_1" />
       </div>
     </section>
     <section v-if="articles">
@@ -116,14 +116,7 @@ const newsletterSubmitEvent = () => {
             </Button>
           </div>
           <div class="col-fixed mx-auto">
-            <img
-              class="mb-4 xl:mb-7"
-              src="https://fakeimg.pl/300x600/?text=AD Here"
-              style="max-width: 100%"
-              width="300"
-              height="600"
-              alt="advertisement"
-            />
+            <HtlAd layout="rectangle" slot="htlad-gothamist_interior_midpage_repeating" />
           </div>
         </div>
         <!-- newsletter -->


### PR DESCRIPTION
- create an ad component that respects the sensitive content flag and has some basic classes to reserve minimum sizes for layout purposes
- replace placeholder ads with real ad slot divs
- fix article ad insertion and update it to handle multiple ads (every 6 paragraphs)
- update htl resources to point to new gothamistv3 css and js