### PR TITLE
streamfield image update +

### DIFF
--- a/components/AuthorProfile.vue
+++ b/components/AuthorProfile.vue
@@ -51,7 +51,8 @@ const imageSizePx = ref(imageSize.value + 'px')
         <v-flexible-link :to="profileLink" class="no-underline">
           <h5>{{ profile.name }}</h5>
         </v-flexible-link>
-        <span v-if="!profile.social">
+        <!-- profile.social is not supported in the response yet. This will be updated as part of a CMS ticket -->
+        <span v-if="profile.social">
           <v-share-tools class="">
             <v-share-tools-item service="facebook" username="gothamist" />
             <v-share-tools-item service="twitter" username="gothamist" />

--- a/components/NewsletterArticle.vue
+++ b/components/NewsletterArticle.vue
@@ -12,6 +12,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  pinStartTopOffset: {
+    type: String,
+    default: '68px', // height of the header
+  },
 })
 const newsletterElm = ref(null)
 const emit = defineEmits(['submit'])
@@ -22,7 +26,7 @@ const initScrollTrigger = () => {
     trigger: `#${props.triggerID}`,
     id: 'pinnedNewsletterID',
     pin: true,
-    start: '1px top',
+    start: `1px ${props.pinStartTopOffset}`,
     endTrigger: `#${props.pinEndTriggerID}`,
     end: `top 0%+=${newsletterElm.value.offsetHeight + 40}px`,
     //markers: true,

--- a/components/Streamfield/StreamfieldImage.vue
+++ b/components/Streamfield/StreamfieldImage.vue
@@ -18,5 +18,6 @@ defineProps<{
     :credit="`Photo by ${block.value.image.credit}`"
     :credit-url="block.value.image.creditLink"
     :sizes="[1, 2]"
+    :ratio="[block.value.image.width, block.value.image.height]"
   />
 </template>


### PR DESCRIPTION
added the max width and height as the ratio prop to fix the streamfield image defaulting to 3:2 ratio, removed social icons from AuthorProfile comp, and updated the top offset of the pinned newsletter on the article page to respect the new progress header