### PR TITLE
VCardMetadata comment count hide

### DIFF
--- a/components/VCardMetadata.vue
+++ b/components/VCardMetadata.vue
@@ -15,7 +15,7 @@ const props = defineProps({
   },
   showComments: {
     type: Boolean,
-    default: true,
+    default: false,
   },
   showDescription: {
     type: Boolean,

--- a/components/VCardMetadata.vue
+++ b/components/VCardMetadata.vue
@@ -15,7 +15,7 @@ const props = defineProps({
   },
   showComments: {
     type: Boolean,
-    default: false,
+    default: false, // setting to false untill we have support for comment counts
   },
   showDescription: {
     type: Boolean,


### PR DESCRIPTION
in the VCardMetadata comp, I set the showComments prop to false by default, so to hide the comment count till we have that supported