### PR TITLE
Bono/goth 432

### DIFF
--- a/assets/scss/extensions.scss
+++ b/assets/scss/extensions.scss
@@ -294,6 +294,14 @@ $img-height: 212px;
 $img-width-small: 158px;
 $img-width-mobile: 106px;
 $img-height-mobile: 106px;
+.image-with-caption {
+  .image-with-caption-description {
+    @include font-config($type-paragraph3);
+  }
+  .image-with-caption-credit-link {
+    @include font-config($type-caption);
+  }
+}
 .v-card .image-with-caption {
   width: $img-width !important;
   @include media(#{$mobileBreakpoint}) {
@@ -314,7 +322,7 @@ $img-height-mobile: 106px;
   background: transparent;
   border: solid 1px var(--white);
   color: var(--white);
-  &:hover{
+  &:hover {
     background: var(--white);
     .p-button-label {
       color: var(--black) !important;
@@ -592,7 +600,6 @@ $img-height-mobile: 106px;
 }
 
 .v-card-metadata {
-
 }
 .v-byline,
 .comments {

--- a/components/ArticlePageHeader.vue
+++ b/components/ArticlePageHeader.vue
@@ -37,8 +37,8 @@ import VShareToolsItem from '@nypublicradio/nypr-design-system-vue3/v2/src/compo
 
 <template>
 <header class="article-page-header">
-  <div class="article-page-header-progress">
-    <div class="article-page-header-contents py-3 px-4 md:px-5 flex align-items-center justify-content-between">
+  <section class="article-page-header-progress">
+    <div class="article-page-header-contents content py-0 my-3 flex align-items-center justify-content-between">
       <div class="article-page-header-left">
         <v-flexible-link to="/" raw>
           <LogoGothamist class="article-page-header-logo" />
@@ -131,7 +131,7 @@ import VShareToolsItem from '@nypublicradio/nypr-design-system-vue3/v2/src/compo
         <Button icon="pi pi-bars" class="p-button p-component p-button-icon-only p-button-text p-button-rounded -mr-2" @click="openSidebar" />
       </div>
     </div>
-  </div>
+  </section>
 </header>
 </template>
 

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -70,14 +70,16 @@ const latestArticles = computed(() => props.articles.slice(1))
           :maxHeight="article.listingImage?.height"
           :quality="80"
         >
+          <div></div>
           <v-card-metadata :article="article" :showComments="false" />
         </v-card>
+        <hr v-if="index < latestArticles.length - 1" class="my-3 block" />
       </div>
       <div class="mb-1">
         <HtlAd
-        layout="rectangle"
-        slot="htlad-gothamist_index_topper"
-        fineprint="Gothamist is funded by sponsors and member donations"
+          layout="rectangle"
+          slot="htlad-gothamist_index_topper"
+          fineprint="Gothamist is funded by sponsors and member donations"
         />
       </div>
     </div>

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -127,7 +127,7 @@ const getGalleryLink = computed(() => {
             <byline class="mb-3 pt-4" :article="article" />
             <div>
               <div id="pinned-newsletter" style="min-width: 300px">
-                <hr class="black mb-4" />
+                <hr class="mb-4" />
                 <newsletter-article
                   class="pb-8"
                   triggerID="pinned-newsletter"
@@ -164,7 +164,7 @@ const getGalleryLink = computed(() => {
               >
                 <Button
                   class="p-button-rounded p-button-sm p-button-raised p-button-secondary"
-                  :label="`View all (${galleryLength})`"
+                  :label="`View all ${galleryLength}`"
                 />
               </v-flexible-link>
             </div>
@@ -190,10 +190,10 @@ const getGalleryLink = computed(() => {
           <div class="col-fixed hidden xxl:block"></div>
           <div class="col overflow-hidden article-column">
             <v-streamfield
-                class="article-body"
-                :streamfield-blocks="article.body"
-                @all-blocks-mounted="handleArticleMounted"
-              />
+              class="article-body"
+              :streamfield-blocks="article.body"
+              @all-blocks-mounted="handleArticleMounted"
+            />
           </div>
         </div>
       </div>
@@ -267,13 +267,13 @@ const getGalleryLink = computed(() => {
       flex-grow: 1;
       flex-basis: 0;
       padding: 0.5rem;
-      width: calc(100% -  330px - 15px);
+      width: calc(100% - 330px - 15px);
     }
     .article-body > *.rte-text {
       width: 100%;
     }
     .article-body > *.rte-text > * {
-      width: calc(100% -  330px - 15px);
+      width: calc(100% - 330px - 15px);
     }
     .article-body > *.wide-module,
     .article-body > streamfield-pull-quote,

--- a/pages/[sectionSlug]/photos/[gallerySlug].vue
+++ b/pages/[sectionSlug]/photos/[gallerySlug].vue
@@ -141,10 +141,13 @@ onUnmounted(() => {
             :ratio="[slide.image.width, slide.image.height]"
             :allow-preview="true"
           />
-          <hr class="mt-4 xl:mt-4 mb-2 xl:mb-4" />
+          <hr class="my-3" />
           <template v-if="index == 2 || index % 6 === 0">
-            <HtlAd layout="rectangle" slot="htlad-gothamist_interior_midpage_repeating" />
-            <hr class="mt-4 xl:mt-4 mb-2 xl:mb-4" />
+            <HtlAd
+              layout="rectangle"
+              slot="htlad-gothamist_interior_midpage_repeating"
+            />
+            <hr class="my-3" />
           </template>
         </div>
       </div>
@@ -187,12 +190,15 @@ onUnmounted(() => {
   background: var(--black-400);
 }
 
-.sectionSlug-photos-gallerySlug .image-with-caption-description {
-  @include font-config($type-paragraph3);
+.sectionSlug-photos-gallerySlug
+  .image-with-caption
+  .image-with-caption-description {
   margin-top: 1rem;
 }
 
-.sectionSlug-photos-gallerySlug .image-with-caption-credit-link {
+.sectionSlug-photos-gallerySlug
+  .image-with-caption
+  .image-with-caption-credit-link {
   @include font-config($type-fineprint);
   color: var(--black400) !important;
   margin-top: 0.5rem;


### PR DESCRIPTION
- image-with-caption byline is now caption type style and the caption is now paragraph3 style
- image gallery caption styles removed as the above cascades
- article page header now uses the `<section>` content class relationship to keep the default header and article header aligned and max-width of 1440px
- Gothamist homepage topper: added lines in between to match and fixed the flex in-between with the title and byline
- article newsletter, made the line under the social share not black, looks better.