### PR TITLE
Use htlbid.forceRefesh to clear ads

### DIFF
--- a/plugins/htlbid.client.ts
+++ b/plugins/htlbid.client.ts
@@ -34,12 +34,9 @@ export default defineNuxtPlugin(() => {
         })
     }
     const clearAds = () => {
-      document.querySelectorAll('.htl-ad').forEach(function (el) {
-        el.remove()
-      })
-      document.querySelectorAll('.htl-ad-gpt').forEach(function (el) {
-        el.remove()
-      })
+        htlbid.cmd.push(() => {
+            htlbid.forceRefresh()
+        })
     }
     return {
         provide: {


### PR DESCRIPTION
This replaces manually deleting the ad divs, which is something we were doing to prevent multiple ads from appearing in the same slot and breaking layouts. That doesn't seem to be happening so far with this setup up though, so i think it's good.