### PR TITLE
hamburger menu a11y fixes

### DIFF
--- a/components/ArticlePageHeader.vue
+++ b/components/ArticlePageHeader.vue
@@ -31,10 +31,12 @@ const props = defineProps({
   },
 })
 const sidebarIsOpen = useSidebarIsOpen()
+const sidebarOpenedFrom = useSidebarOpenedFrom()
 const strapline = await useStrapline()
 const progressPercentage = computed(() => `${props.progress}%`)
-const openSidebar = () => {
+const openSidebar = (e) => {
   sidebarIsOpen.value = true
+  sidebarOpenedFrom.value = e.target
 }
 </script>
 
@@ -140,6 +142,8 @@ const openSidebar = () => {
           <Button
             icon="pi pi-bars"
             class="p-button p-component p-button-icon-only p-button-text p-button-rounded -mr-2"
+            aria-label="Open the navigation menu"
+            aria-expanded="false"
             @click="openSidebar"
           />
         </div>

--- a/components/GothamistMainHeader.vue
+++ b/components/GothamistMainHeader.vue
@@ -10,9 +10,11 @@ defineProps<{
 }>()
 const { $analytics } = useNuxtApp()
 const sidebarIsOpen = useSidebarIsOpen()
+const sidebarOpenedFrom = useSidebarOpenedFrom()
 const strapline = await useStrapline()
-const openSidebar = () => {
+const openSidebar = (e) => {
   sidebarIsOpen.value = true
+  sidebarOpenedFrom.value = e.target
 }
 
 const trackClick = (category, label) => {
@@ -55,7 +57,8 @@ const trackClick = (category, label) => {
       <Button
         icon="pi pi-bars"
         class="p-button p-component p-button-icon-only p-button-text p-button-rounded -mr-2"
-        aria-label="menu button"
+        aria-label="Open the navigation menu"
+        aria-expanded="false"
         @click="openSidebar"
       />
     </div>

--- a/components/GothamistSidebarContents.vue
+++ b/components/GothamistSidebarContents.vue
@@ -21,13 +21,9 @@ const emit = defineEmits(['menu-list-click'])
       />
     </div>
     <div class="sidebar-contents-bottom mb-5 md:mb-6">
-      <v-flexible-link to="mailto:tips@gothamist.com" raw>
-        <Button
-          class="sidebar-button-send-a-story p-button-rounded mb-5 w-full"
-        >
-          <span class="p-button-label">Send a story idea</span>
-        </Button>
-      </v-flexible-link>
+      <a class="sidebar-button-send-a-story mod-button p-button p-button-rounded mb-5 w-full" href="mailto:tips@gothamist.com" target="_blank" rel="noopener noreferrer">
+        <span class="p-button-label">Send a story idea</span>
+      </a>
       <hr class="white mb-3" />
       <v-share-tools class="mb-3">
         <span>Follow Us</span>
@@ -49,14 +45,12 @@ const emit = defineEmits(['menu-list-click'])
           <LogoNypr />
         </div>
       </div>
-      <v-flexible-link :to="`${donateUrlBase}&utm_campaign=${utmCampaign}`" raw>
-        <Button class="p-button-rounded w-full">
-          <span class="p-button-label">
-            <span class="pi pi-heart-fill"></span>
-            Support us today
-          </span>
-        </Button>
-      </v-flexible-link>
+      <a class="mod-button p-button p-button-rounded mb-5 w-full" :href="`${donateUrlBase}&utm_campaign=${utmCampaign}`" target="_blank" rel="noopener noreferrer">
+        <span class="p-button-label">
+          <span class="pi pi-heart-fill"></span>
+          Support us today
+        </span>
+      </a>
     </div>
   </div>
 </template>
@@ -98,5 +92,33 @@ const emit = defineEmits(['menu-list-click'])
 .sidebar-button-send-a-story.p-button {
   background: var(--black-300);
   color: var(--text-color);
+}
+
+
+a.mod-button.pi {
+    padding: 8px 6px 7px 6px !important;
+}
+
+a.mod-button {
+  display:block;
+  text-decoration: none;
+}
+
+a.mod-button:hover {
+  text-decoration: none;
+  color: var(--button-text-hover-color) !important;
+  background: var(--button-hover-bg);
+  border-color: var(--button-hover-border-color);
+}
+
+a.mod-button:active {
+  background: var(--button-active-bg);
+  color: var(--button-text-active-color);
+}
+
+a.mod-button:focus {
+  box-shadow: 0 0 0 0.2rem #d8d7af;
+  outline: 0 none;
+  outline-offset: 0;
 }
 </style>

--- a/composables/states.ts
+++ b/composables/states.ts
@@ -2,6 +2,7 @@ import Navigation from "./types/Navigation"
 
 export const useSensitiveContent = () => useState<boolean>('sensitiveContent', () => false)
 export const useSidebarIsOpen = () => useState<boolean>('sidebarIsOpen', () => false)
+export const useSidebarOpenedFrom = () => useState<any>('sidebarOpenedFrom', () => {})
 export const useMembershipStatus = () => useState<string>('membershipStatus', () => 'status-unknown')
 export const useNavigation = () => useState<Navigation>('navigation', () => ({
     id: 0,

--- a/composables/states.ts
+++ b/composables/states.ts
@@ -2,7 +2,7 @@ import Navigation from "./types/Navigation"
 
 export const useSensitiveContent = () => useState<boolean>('sensitiveContent', () => false)
 export const useSidebarIsOpen = () => useState<boolean>('sidebarIsOpen', () => false)
-export const useSidebarOpenedFrom = () => useState<any>('sidebarOpenedFrom', () => {})
+export const useSidebarOpenedFrom = () => useState<HTMLElement>('sidebarOpenedFrom', () => undefined)
 export const useMembershipStatus = () => useState<string>('membershipStatus', () => 'status-unknown')
 export const useNavigation = () => useState<Navigation>('navigation', () => ({
     id: 0,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -142,7 +142,7 @@ watch(route, (value) => {
       "
     />
     <!-- End Google Tag Manager (noscript) -->
-    <div :aria-hidden="sidebarOpen ? 'true' : 'false'">
+    <div>
       <div v-if="!sensitiveContent" class="htlad-skin" />
       <div
         class="leaderboard-ad-wrapper flex justify-content-center align-items-center"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,10 +27,8 @@ const sidebarOpen = useSidebarIsOpen()
 const sidebarOpenedFrom = useSidebarOpenedFrom()
 const closeSidebar = () => {
   sidebarOpen.value = false
-  if (sidebarOpenedFrom.value?.focus) {
-    sidebarOpenedFrom.value.focus()
-  }
 }
+
 let sidebarElements = undefined
 let firstElement = undefined
 let lastElement = undefined
@@ -39,6 +37,12 @@ const handleSidebarShown = () => {
   sidebarElements = Array.from(document.querySelectorAll('.p-sidebar a:not([disabled]), .p-sidebar button:not([disabled])')).filter(element => element.clientWidth + element.clientHeight !== 0)
   firstElement = sidebarElements[0]
   lastElement = sidebarElements[sidebarElements.length - 1]
+}
+
+const handleSidebarHidden = () => {
+  if (sidebarOpenedFrom.value?.focus) {
+    sidebarOpenedFrom.value.focus()
+  }
 }
 
 const handleSidebarTab = (e) => {
@@ -179,6 +183,7 @@ watch(route, (value) => {
     ariaCloseLabel="close the navigation menu"
     class="gothamist-sidebar px-3 md:px-4"
     @show="handleSidebarShown"
+    @hide="handleSidebarHidden"
     @keydown.esc="closeSidebar"
     @keydown.tab="handleSidebarTab"
     @keydown.shift.tab="handleSidebarShiftTab"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,6 @@
 import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
 import { ref, onMounted } from 'vue'
 import { useRuntimeConfig } from '#app'
-import { useSidebarIsOpen } from '~~/composables/states.js'
 
 const config = useRuntimeConfig()
 const route = useRoute()
@@ -19,11 +18,43 @@ const breakingNews = await findBreakingNews().then(({ data }) =>
 const productBanners = await findProductBanners().then(({ data }) =>
   normalizeFindProductBannersResponse(data)
 )
+const isSponsored = route.name === 'sponsored'
+const strapline = await useStrapline()
+
+
 const sensitiveContent = useSensitiveContent()
 const sidebarOpen = useSidebarIsOpen()
-const isSponsored = route.name === 'sponsored'
-const closeSidebar = () => (sidebarOpen.value = false)
-const strapline = await useStrapline()
+const sidebarOpenedFrom = useSidebarOpenedFrom()
+const closeSidebar = () => {
+  sidebarOpen.value = false
+  if (sidebarOpenedFrom.value?.focus) {
+    sidebarOpenedFrom.value.focus()
+  }
+}
+let sidebarElements = undefined
+let firstElement = undefined
+let lastElement = undefined
+
+const handleSidebarShown = () => {
+  sidebarElements = Array.from(document.querySelectorAll('.p-sidebar a:not([disabled]), .p-sidebar button:not([disabled])')).filter(element => element.clientWidth + element.clientHeight !== 0)
+  firstElement = sidebarElements[0]
+  lastElement = sidebarElements[sidebarElements.length - 1]
+}
+
+const handleSidebarTab = (e) => {
+  if (!e.shiftKey && document.activeElement === lastElement) {
+      firstElement.focus()
+      e.preventDefault()
+  }
+}
+
+const handleSidebarShiftTab = (e) => {
+  if (document.activeElement === firstElement) {
+    lastElement.focus();
+    e.preventDefault()
+  }
+}
+
 
 const trackSidebarClick = (label) => {
   //emitted mobile menu click event
@@ -111,62 +142,69 @@ watch(route, (value) => {
       "
     />
     <!-- End Google Tag Manager (noscript) -->
-    <div v-if="!sensitiveContent" class="htlad-skin" />
-    <div
-      class="leaderboard-ad-wrapper flex justify-content-center align-items-center"
-    >
-      <HtlAd
-        v-if="route.name === 'index'"
-        layout="leaderboard"
-        slot="htlad-gothamist_index_leaderboard_1"
-      />
-      <HtlAd
-        v-else
-        layout="leaderboard"
-        slot="htlad-gothamist_interior_leaderboard_1"
-      />
-    </div>
-    <GothamistMainHeader
-      :navigation="navigation"
-      :showLogo="route.name !== 'index'"
-      :donateUrlBase="config.donateUrlBase"
-      utmCampaign="homepage-header"
-    />
-    <Sidebar
-      v-model:visible="sidebarOpen"
-      :baseZIndex="6000"
-      position="right"
-      data-style-mode="dark"
-      class="gothamist-sidebar px-3 md:px-4"
-    >
-      <template v-slot:header>
-        <div class="gothamist-sidebar-header flex md:hidden">
-          <v-flexible-link
-            to="/"
-            raw
-            @click="trackSidebarClick('sidebar logo')"
-          >
-            <LogoGothamist class="gothamist-sidebar-header-logo pr-2" />
-          </v-flexible-link>
-          <div class="gothamist-sidebar-header-tagline" v-html="strapline" />
-        </div>
-      </template>
-      <template v-slot:default>
-        <GothamistSidebarContents
-          :navigation="navigation"
-          :donateUrlBase="config.donateUrlBase"
-          @menuListClick="trackSidebarClick($event)"
-          utmCampaign="goth_hamburger"
-          class="mt-3"
+    <div :aria-hidden="sidebarOpen ? 'true' : 'false'">
+      <div v-if="!sensitiveContent" class="htlad-skin" />
+      <div
+        class="leaderboard-ad-wrapper flex justify-content-center align-items-center"
+      >
+        <HtlAd
+          v-if="route.name === 'index'"
+          layout="leaderboard"
+          slot="htlad-gothamist_index_leaderboard_1"
         />
-      </template>
-    </Sidebar>
-    <main>
-      <slot />
-    </main>
-    <scroll-to-top-button />
-    <gothamist-footer :navigation="navigation" />
+        <HtlAd
+          v-else
+          layout="leaderboard"
+          slot="htlad-gothamist_interior_leaderboard_1"
+        />
+      </div>
+      <GothamistMainHeader
+        :navigation="navigation"
+        :showLogo="route.name !== 'index'"
+        :donateUrlBase="config.donateUrlBase"
+        utmCampaign="homepage-header"
+      />
+      <main>
+        <slot />
+      </main>
+      <scroll-to-top-button />
+      <gothamist-footer :navigation="navigation" />
+    </div>
   </div>
+  <Sidebar
+    v-model:visible="sidebarOpen"
+    :baseZIndex="6000"
+    position="right"
+    data-style-mode="dark"
+    ariaCloseLabel="close the navigation menu"
+    class="gothamist-sidebar px-3 md:px-4"
+    @show="handleSidebarShown"
+    @keydown.esc="closeSidebar"
+    @keydown.tab="handleSidebarTab"
+    @keydown.shift.tab="handleSidebarShiftTab"
+  >
+    <template v-slot:header>
+      <div class="gothamist-sidebar-header flex md:hidden">
+        <v-flexible-link
+          to="/"
+          raw
+          @click="trackSidebarClick('sidebar logo')"
+        >
+          <LogoGothamist class="gothamist-sidebar-header-logo pr-2" />
+        </v-flexible-link>
+        <div class="gothamist-sidebar-header-tagline" v-html="strapline" />
+      </div>
+    </template>
+    <template v-slot:default>
+      <GothamistSidebarContents
+        :navigation="navigation"
+        :donateUrlBase="config.donateUrlBase"
+        @menuListClick="trackSidebarClick($event)"
+        utmCampaign="goth_hamburger"
+        class="mt-3"
+      />
+    </template>
+  </Sidebar>
 </template>
 
 <style lang="scss">


### PR DESCRIPTION
- Add aria-labels to menu open and close buttons
- Add aria-expanded=false tag to the menu open button
- Turn buttons wrapped in links into normal links
- Trap tab focus in the menu when it's open
- return tab focus to previous element when closing the menu
- allow closing the menu with the "Esc" key