### PR TITLE
performance tweaks

### DIFF
--- a/components/ArticlePageHeader.vue
+++ b/components/ArticlePageHeader.vue
@@ -32,7 +32,7 @@ const props = defineProps({
 })
 const sidebarIsOpen = useSidebarIsOpen()
 const sidebarOpenedFrom = useSidebarOpenedFrom()
-const strapline = await useStrapline()
+const strapline = useStrapline()
 const progressPercentage = computed(() => `${props.progress}%`)
 const openSidebar = (e) => {
   sidebarIsOpen.value = true

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -64,7 +64,6 @@ const handleSidebarShiftTab = (e) => {
   }
 }
 
-
 const trackSidebarClick = (label) => {
   //emitted mobile menu click event
   $analytics.sendEvent('click_tracking', {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -21,8 +21,9 @@ const productBannersPromise = findProductBanners().then(({ data }) =>
   normalizeFindProductBannersResponse(data)
 )
 
-const [navigation, breakingNews, productBanners] = await
-  Promise.all([navigationPromise, breakingNewsPromise, productBannersPromise])
+const [navigation, breakingNews, productBanners] = await Promise.all(
+  [navigationPromise, breakingNewsPromise, productBannersPromise]
+)
 
 const isSponsored = route.name === 'sponsored'
 const strapline = useStrapline()

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,27 +1,31 @@
 <script setup lang="ts">
 import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
-import { ref, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { useRuntimeConfig } from '#app'
 
 const config = useRuntimeConfig()
 const route = useRoute()
 const { $htlbid, $analytics } = useNuxtApp()
-const navigation = await findNavigation().then(({ data }) =>
-  normalizeFindNavigationResponse(data)
-)
-const navigationState = useNavigation()
-navigationState.value = navigation
 
-const breakingNews = await findBreakingNews().then(({ data }) =>
+const navigationState = useNavigation()
+const navigationPromise = findNavigation().then(({ data }) => {
+  const navigationData = normalizeFindNavigationResponse(data)
+  navigationState.value = navigationData
+  return navigationData
+})
+
+const breakingNewsPromise = findBreakingNews().then(({ data }) =>
   normalizeFindBreakingNewsResponse(data)
 )
-const productBanners = await findProductBanners().then(({ data }) =>
+const productBannersPromise = findProductBanners().then(({ data }) =>
   normalizeFindProductBannersResponse(data)
 )
+
+const [navigation, breakingNews, productBanners] = await
+  Promise.all([navigationPromise, breakingNewsPromise, productBannersPromise])
+
 const isSponsored = route.name === 'sponsored'
-const strapline = await useStrapline()
-
-
+const strapline = useStrapline()
 const sensitiveContent = useSensitiveContent()
 const sidebarOpen = useSidebarIsOpen()
 const sidebarOpenedFrom = useSidebarOpenedFrom()

--- a/pages/tags/[tagSlug].vue
+++ b/pages/tags/[tagSlug].vue
@@ -6,15 +6,16 @@ import VImageWithCaption from '@nypublicradio/nypr-design-system-vue3/v2/src/com
 const { $analytics, $htlbid } = useNuxtApp()
 const route = useRoute()
 const tagSlug = route.params.tagSlug
-const curatedTagPage = await findPage(`tags/${tagSlug}`).then(
+const curatedTagPagePromise = await findPage(`tags/${tagSlug}`).then(
   ({ data }) => data?.value && (normalizeFindPageResponse(data) as TagPage)
 )
-
-const articlesToShow = ref(10)
-
-const articles = await findArticlePages({
+const articlesPromise = await findArticlePages({
   tag_slug: tagSlug,
 }).then(({ data }) => normalizeFindArticlePagesResponse(data))
+
+const [curatedTagPage, articles] = await Promise.all([curatedTagPagePromise, articlesPromise])
+
+const articlesToShow = ref(10)
 
 const tagName =
   articles[0]?.tags.find((tag) => tag.slug === tagSlug)?.name || tagSlug

--- a/pages/tags/[tagSlug].vue
+++ b/pages/tags/[tagSlug].vue
@@ -6,10 +6,10 @@ import VImageWithCaption from '@nypublicradio/nypr-design-system-vue3/v2/src/com
 const { $analytics, $htlbid } = useNuxtApp()
 const route = useRoute()
 const tagSlug = route.params.tagSlug
-const curatedTagPagePromise = await findPage(`tags/${tagSlug}`).then(
+const curatedTagPagePromise = findPage(`tags/${tagSlug}`).then(
   ({ data }) => data?.value && (normalizeFindPageResponse(data) as TagPage)
 )
-const articlesPromise = await findArticlePages({
+const articlesPromise = findArticlePages({
   tag_slug: tagSlug,
 }).then(({ data }) => normalizeFindArticlePagesResponse(data))
 


### PR DESCRIPTION
Parallelizes API calls with `Promise.all` when possible instead of `await`ing them one by one.
Also brings the `error` layout in line with the `default` layout.