### PR TITLE
updated DS tag-large style & flexible link, fixed boroughs etc...

### DIFF
--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -1,4 +1,4 @@
-//@import './extensions';
+@import './extensions';
 
 $contentWidth: 1440px;
 $mobileBreakpoint: '<lg';

--- a/components/Boroughs.vue
+++ b/components/Boroughs.vue
@@ -6,23 +6,23 @@ import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/compone
     <div class="boroughs-header mb-5 xl:mb-7 py-2">WNYC Presents</div>
     <div class="boroughs-content">
       We cover stories that make New York work for New Yorkers. Browse
-      <v-flexible-link to="/tags/manhattan" class="tag-large">
-        Manhattan
+      <v-flexible-link to="/tags/manhattan" raw rawHover="underline">
+        <div class="tag-large">Manhattan</div>
       </v-flexible-link>
-      <v-flexible-link to="/tags/brooklyn" class="tag-large">
-        Brooklyn
+      <v-flexible-link to="/tags/brooklyn" raw rawHover="underline">
+        <div class="tag-large">Brooklyn</div>
       </v-flexible-link>
-      <v-flexible-link to="/tags/the-bronx" class="tag-large">
-        The Bronx
+      <v-flexible-link to="/tags/the-bronx" raw rawHover="underline">
+        <div class="tag-large">The Bronx</div>
       </v-flexible-link>
-      <v-flexible-link to="/tags/staten-island" class="tag-large">
-        Staten Island
+      <v-flexible-link to="/tags/staten-island" raw rawHover="underline">
+        <div class="tag-large">Staten Island</div>
       </v-flexible-link>
-      <v-flexible-link to="/tags/queens" class="tag-large">
-        Queens
+      <v-flexible-link to="/tags/queens" raw rawHover="underline">
+        <div class="tag-large">Queens</div>
       </v-flexible-link>
-      <v-flexible-link to="/tags/new-jersey" class="tag-large">
-        New Jersey
+      <v-flexible-link to="/tags/new-jersey" raw rawHover="underline">
+        <div class="tag-large">New Jersey</div>
       </v-flexible-link>
     </div>
     <div class="boroughs-footer mt-4 xl:mt-5">
@@ -59,6 +59,7 @@ import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/compone
   display: inline-block;
   width: fit-content;
   margin: auto;
+  font-weight: 600;
   @include media('>lg') {
     margin: 0 0.25rem 0.5rem;
     display: inline-block;

--- a/components/GothamistMainHeader.vue
+++ b/components/GothamistMainHeader.vue
@@ -81,6 +81,10 @@ const trackClick = (category, label) => {
 .gothamist-header-logo {
   height: 34px;
   width: auto;
+  @include media('<xs') {
+    height: 25px;
+    align-self: center;
+  }
 }
 
 .gothamist-header-left,

--- a/components/ScrollToTopButton.vue
+++ b/components/ScrollToTopButton.vue
@@ -92,6 +92,7 @@ onBeforeUnmount(() => {
     bottom: 0;
     right: 0;
     box-shadow: none;
+    z-index: 999 !important;
     width: 68px;
     height: 68px;
     @include media('<lg') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@nypublicradio/nypr-design-system-vue3": "^0.4.14",
+        "@nypublicradio/nypr-design-system-vue3": "^0.4.15",
         "@sentry/tracing": "^6.18.2",
         "@sentry/vue": "^6.18.2",
         "@vitejs/plugin-vue": "^2.3.2",
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/@nypublicradio/nypr-design-system-vue3": {
-      "version": "0.4.14",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.14/18ab97ba4d58a002243a94ff1cac34b2e54f0cbf",
-      "integrity": "sha512-0IdUiG0JaNc0rwl7h7dd6ZretddhVtKESrjaoywnO557PZqKBuhem3BCVAWbAKhp/NeSzbwkC63/baQTXAqk1w==",
+      "version": "0.4.15",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.15/3d0e71f763625d0c7230a9df38bd87761d5ce585",
+      "integrity": "sha512-MzlTVt/4BUKYa62wFaksvkUxXkuDkbfvMxfoAhg5i1nhi7RksIQ0Gv1KLKbjo010PUM9z3Pzzpv09XZKJ3makw==",
       "dependencies": {
         "@nuxt/vite-builder": "^3.0.0-rc.4",
         "axios": "^0.25.0",
@@ -14638,9 +14638,9 @@
       }
     },
     "@nypublicradio/nypr-design-system-vue3": {
-      "version": "0.4.14",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.14/18ab97ba4d58a002243a94ff1cac34b2e54f0cbf",
-      "integrity": "sha512-0IdUiG0JaNc0rwl7h7dd6ZretddhVtKESrjaoywnO557PZqKBuhem3BCVAWbAKhp/NeSzbwkC63/baQTXAqk1w==",
+      "version": "0.4.15",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.15/3d0e71f763625d0c7230a9df38bd87761d5ce585",
+      "integrity": "sha512-MzlTVt/4BUKYa62wFaksvkUxXkuDkbfvMxfoAhg5i1nhi7RksIQ0Gv1KLKbjo010PUM9z3Pzzpv09XZKJ3makw==",
       "requires": {
         "@nuxt/vite-builder": "^3.0.0-rc.4",
         "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@nypublicradio/nypr-design-system-vue3": "^0.4.14",
+    "@nypublicradio/nypr-design-system-vue3": "^0.4.15",
     "@sentry/tracing": "^6.18.2",
     "@sentry/vue": "^6.18.2",
     "@vitejs/plugin-vue": "^2.3.2",


### PR DESCRIPTION
- updated DS
- - flexible link RAW now affects itself and all children
- - tag-large classed updated to fix the style issue in the ticket
- updated the BOROUGHS link on the home page by putting the tag-large inside the flexible link and adding RAW and RAWHOVER
- on <xs (375), I made the header logo smaller so the hamburger menu did not push off the screen and cause horz scroll
- scroll back to top button z-index fixed so it does not go over the header