### PR TITLE
GOTH-439 Heading levels being skipped in the accessibility tree

### DIFF
--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -14,13 +14,6 @@ const props = defineProps({
     type: String,
     default: 'news',
   },
-  // A heading for the accessibility tree. Invisible in the design but will label this
-  // section for screen readers. Only needed if you're not already providing a heading
-  // to this section in the layout where you put this component
-  accessibleHeading: {
-    type: String,
-    default: null
-  },
 })
 
 const routeSectionSlug = ref(props.slug)
@@ -52,7 +45,6 @@ const articlesSm = ref([
     <div v-if="articles" class="recirculation">
       <div class="grid gutter-x-30">
         <div class="col-12 xl:col-8">
-          <h2 v-if="accessibleHeading" class="sr-only">{{accessibleHeading}}</h2>
           <v-card
             class="article-lg mod-vertical mod-featured2 mod-large mb-4"
             :image="useImageUrl(articleLg?.listingImage)"

--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -14,14 +14,13 @@ const props = defineProps({
     type: String,
     default: 'news',
   },
-  heading: {
+  // A heading for the accessibility tree. Invisible in the design but will label this
+  // section for screen readers. Only needed if you're not already providing a heading
+  // to this section in the layout where you put this component
+  accessibleHeading: {
     type: String,
-    default: 'Featured Stories'
+    default: null
   },
-  headingLevel: {
-    type: Number,
-    default: 2
-  }
 })
 
 const routeSectionSlug = ref(props.slug)
@@ -53,7 +52,7 @@ const articlesSm = ref([
     <div v-if="articles" class="recirculation">
       <div class="grid gutter-x-30">
         <div class="col-12 xl:col-8">
-          <div role="heading" :aria-level="headingLevel" class="sr-only">{{heading}}</div>
+          <h2 v-if="accessibleHeading" class="sr-only">{{accessibleHeading}}</h2>
           <v-card
             class="article-lg mod-vertical mod-featured2 mod-large mb-4"
             :image="useImageUrl(articleLg?.listingImage)"

--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -14,6 +14,14 @@ const props = defineProps({
     type: String,
     default: 'news',
   },
+  heading: {
+    type: String,
+    default: 'Featured Stories'
+  },
+  headingLevel: {
+    type: Number,
+    default: 2
+  }
 })
 
 const routeSectionSlug = ref(props.slug)
@@ -45,6 +53,7 @@ const articlesSm = ref([
     <div v-if="articles" class="recirculation">
       <div class="grid gutter-x-30">
         <div class="col-12 xl:col-8">
+          <div role="heading" :aria-level="headingLevel" class="sr-only">{{heading}}</div>
           <v-card
             class="article-lg mod-vertical mod-featured2 mod-large mb-4"
             :image="useImageUrl(articleLg?.listingImage)"

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -38,6 +38,7 @@ const newsletterSubmitEvent = () => {
           :slug="(route?.params?.sectionSlug as string)"
           id="article-recirculation"
           class="my-6"
+          accessible-heading="Featured Stories"
         />
         <div class="mb-6">
           <HtlAd layout="rectangle" slot="htlad-gothamist_interior_midpage_1" />

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -34,17 +34,18 @@ const newsletterSubmitEvent = () => {
         <h1 class="mb-5">{{ sectionTitle }}</h1>
         <hr class="black" />
         <!-- featured area -->
+        <h2 class="sr-only">Featured {{ sectionTitle }} Stories</h2>
         <article-recirculation
           :slug="(route?.params?.sectionSlug as string)"
           id="article-recirculation"
           class="my-6"
-          accessible-heading="Featured Stories"
         />
         <div class="mb-6">
           <HtlAd layout="rectangle" slot="htlad-gothamist_interior_midpage_1" />
         </div>
         <!-- articles -->
         <div v-if="articles" class="grid gutter-x-xl">
+          <h2 class="sr-only">Latest {{ sectionTitle }} Articles</h2>
           <div class="col-1 hidden xl:block"></div>
           <div class="col">
             <div

--- a/pages/sponsored.vue
+++ b/pages/sponsored.vue
@@ -113,7 +113,7 @@ onUnmounted(() => {
           </div>
         </div>
         <hr class="black" />
-        <p v-if="article?.section" class="type-label3 mt-2 mb-4">MORE NEWS</p>
+        <p role="heading" aria-level="2" v-if="article?.section" class="type-label3 mt-2 mb-4">MORE NEWS</p>
         <article-recirculation slug="news" />
         <div class="mt-6 mb-5">
           <hr class="black mb-4" />

--- a/pages/tags/[tagSlug].vue
+++ b/pages/tags/[tagSlug].vue
@@ -87,6 +87,7 @@ const newsletterSubmitEvent = () => {
     <section v-if="articles">
       <div class="content">
         <div class="grid gutter-x-30">
+          <h2 class="sr-only">Latest Articles Tagged "{{tagName}}"</h2>
           <div class="col">
             <div
               v-for="(article, index) in articles.slice(0, articlesToShow)"


### PR DESCRIPTION
Filling out some intermediate headings in the accessibility tree.
Just making invisible screen reader headings for now but maybe we want to consider surfacing some of these titles in the visible design eventually.