### PR TITLE
GOTH-458 fix donate button text color in safari

### DIFF
--- a/components/ArticlePageHeader.vue
+++ b/components/ArticlePageHeader.vue
@@ -222,5 +222,6 @@ const openSidebar = (e) => {
 
 .article-page-header-donate-button {
   max-height: 36px;
+  transform: translate3d(0,0,0);
 }
 </style>


### PR DESCRIPTION
This one weird trick makes `mix-blend-mode: difference` work as expected in Safari.
The text on the donate button should now be readable on an iPhone.