### PR TITLE
GOTH-456 DS update and Boroughs margin update

### DIFF
--- a/components/Boroughs.vue
+++ b/components/Boroughs.vue
@@ -53,12 +53,10 @@ import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/compone
   }
 }
 .boroughs .tag-large {
-  margin: 0 0.15rem 0.25rem 0.25rem;
-  margin-top: 0.5rem !important;
+  margin: 0.25rem 0.15rem 0.25rem 0.25rem;
   text-decoration: none;
   display: inline-block;
   width: fit-content;
-  margin: auto;
   font-weight: 600;
   @include media('>lg') {
     margin: 0 0.25rem 0.5rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@nypublicradio/nypr-design-system-vue3": "^0.4.23",
+        "@nypublicradio/nypr-design-system-vue3": "^0.4.26",
         "@sentry/tracing": "^6.18.2",
         "@sentry/vue": "^6.18.2",
         "@vitejs/plugin-vue": "^2.3.2",
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/@nypublicradio/nypr-design-system-vue3": {
-      "version": "0.4.23",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.23/395f6f8db81336fcbcf4f171d2ee60bc905c45f8",
-      "integrity": "sha512-l25wjM1loB/moRHxbVlQy9NulRIDFMdmnL1EqSWE346YxuLkfnZpQbp1+YGEm/8ki1y/wbqpMQOiFllt0cePMA==",
+      "version": "0.4.26",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.26/b0d5a718c69ae9769c830e6538f980b4799e235a",
+      "integrity": "sha512-i3jVCx8C6YHHGy+7jrQYnRw+ovR/FFXSiw+i4yVzcLSx/4GdHosU2RVfPa/6t3QnAmVZv1fHjEfhbiTjVc3hBA==",
       "dependencies": {
         "@nuxt/vite-builder": "^3.0.0-rc.4",
         "axios": "^0.25.0",
@@ -14638,9 +14638,9 @@
       }
     },
     "@nypublicradio/nypr-design-system-vue3": {
-      "version": "0.4.23",
-      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.23/395f6f8db81336fcbcf4f171d2ee60bc905c45f8",
-      "integrity": "sha512-l25wjM1loB/moRHxbVlQy9NulRIDFMdmnL1EqSWE346YxuLkfnZpQbp1+YGEm/8ki1y/wbqpMQOiFllt0cePMA==",
+      "version": "0.4.26",
+      "resolved": "https://npm.pkg.github.com/download/@nypublicradio/nypr-design-system-vue3/0.4.26/b0d5a718c69ae9769c830e6538f980b4799e235a",
+      "integrity": "sha512-i3jVCx8C6YHHGy+7jrQYnRw+ovR/FFXSiw+i4yVzcLSx/4GdHosU2RVfPa/6t3QnAmVZv1fHjEfhbiTjVc3hBA==",
       "requires": {
         "@nuxt/vite-builder": "^3.0.0-rc.4",
         "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@nypublicradio/nypr-design-system-vue3": "^0.4.23",
+    "@nypublicradio/nypr-design-system-vue3": "^0.4.26",
     "@sentry/tracing": "^6.18.2",
     "@sentry/vue": "^6.18.2",
     "@vitejs/plugin-vue": "^2.3.2",


### PR DESCRIPTION
- changed the word-break and overflow-wrap to normal in the DS extensions.scss for the v-card title
- added a <xs size for the images in the v-card. So, for really small phones, the image gets smaller, which allows the (ARTS & ENTERTAINMENT) tag to fit, thus not cutting off the content... in the DS extensions.scss
- locally, I updated the margins for the boroughs tags... on smaller breakpoints, they had no margins on the left or right due to what seems to be some accidental margin overrides. 