### PR TITLE
OpenWeb fix for data-post-url to beta.gothamist.com

### DIFF
--- a/components/CommentsSection.vue
+++ b/components/CommentsSection.vue
@@ -16,7 +16,7 @@ const getArticleTagsString = () => {
 const getArticleUrl = () => {
   // force the data-post-url to match the beta.gothamist.com url of the article
   // TODO: REMOVE REPLACE WHEN WE GO LIVE
-  var url = props.article.url.replace('gothamist.com', config.betaUrl)
+  var url = props.article.url.replace('//gothamist.com', config.betaUrl)
   return url
 }
 useHead({

--- a/components/CommentsSection.vue
+++ b/components/CommentsSection.vue
@@ -13,6 +13,12 @@ const getArticleTagsString = () => {
   const tags = props.article.tags || []
   return tags.map((tag) => tag.name).join(', ')
 }
+const getArticleUrl = () => {
+  // force the data-post-url to match the beta.gothamist.com url of the article
+  // TODO: REMOVE REPLACE WHEN WE GO LIVE
+  var url = props.article.url.replace('gothamist.com', config.betaUrl)
+  return url
+}
 useHead({
   script: [
     {
@@ -28,7 +34,7 @@ useHead({
   <div class="comments-section">
     <div
       data-spotim-module="conversation"
-      :data-post-url="article.url"
+      :data-post-url="getArticleUrl()"
       :data-article-tags="getArticleTagsString()"
       :data-post-id="String(article.legacyId || article.uuid)"
     ></div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,7 +87,7 @@ export default defineNuxtConfig({
     navigationId: 1,
     systemMessagesId: 2,
     sitewideComponentsId: 2,
-    betaUrl: 'beta.gothamist.com',
+    betaUrl: '//beta.gothamist.com',
   },
   typescript: {
     strict: true

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,6 +87,7 @@ export default defineNuxtConfig({
     navigationId: 1,
     systemMessagesId: 2,
     sitewideComponentsId: 2,
+    betaUrl: 'beta.gothamist.com',
   },
   typescript: {
     strict: true


### PR DESCRIPTION
beta.gothamist.com replacement for the OpenWeb data-post-url attr, will be removed on full launch