### PR TITLE
Add a timestamp to the fetch key to always refresh

### DIFF
--- a/composables/data/navigation.ts
+++ b/composables/data/navigation.ts
@@ -2,7 +2,7 @@ import Navigation from "../types/Navigation"
 
 export async function findNavigation() {
     const config = useRuntimeConfig()
-    return await useAviary(`/navigation/${config.navigationId}`)
+    return await useAviary(`/navigation/${config.navigationId}`, {}, false)
 }
 
 export function normalizeFindNavigationResponse(nav: Record<string, any>): Navigation {

--- a/composables/useAviary.ts
+++ b/composables/useAviary.ts
@@ -1,14 +1,19 @@
 import humps from 'humps'
+import { hash } from 'ohash'
 
 function transformResponseData(data: Record<string, any>): Record<string, any> {
     return humps.camelizeKeys(data)
 }
 
-export default async function useAviary(path: string, options: Record<string, any> = {}) {
+export default async function useAviary(path: string, options: Record<string, any> = {}, refresh: boolean = true) {
     const config = useRuntimeConfig()
+    // Sets a timestamp to include in the values used to create the
+    // fetch key, to force a refresh of the local caching
+    const refreshTimestamp = refresh ? Number(new Date()) : 0
     // manually a generating fetch key here as a workaround for an issue in nuxt3 rc6
     // https://github.com/nuxt/framework/issues/5993
-    const key = path + JSON.stringify(options)
+    const key = hash(['aviary', path, options, refreshTimestamp])
+    console.log('fetch', path, options, key)
     const { data, error } = await useFetch(path, { baseURL: config['API_URL'], key, ...options })
     const transformedData = transformResponseData(data)
     return { data: transformedData, error }

--- a/composables/useAviary.ts
+++ b/composables/useAviary.ts
@@ -5,7 +5,7 @@ function transformResponseData(data: Record<string, any>): Record<string, any> {
     return humps.camelizeKeys(data)
 }
 
-export default async function useAviary(path: string, options: Record<string, any> = {}, refresh: boolean = true) {
+export default async function useAviary(path: string, options: Record<string, any> = {}, refresh = true) {
     const config = useRuntimeConfig()
     // Sets a timestamp to include in the values used to create the
     // fetch key, to force a refresh of the local caching
@@ -13,7 +13,6 @@ export default async function useAviary(path: string, options: Record<string, an
     // manually a generating fetch key here as a workaround for an issue in nuxt3 rc6
     // https://github.com/nuxt/framework/issues/5993
     const key = hash(['aviary', path, options, refreshTimestamp])
-    console.log('fetch', path, options, key)
     const { data, error } = await useFetch(path, { baseURL: config['API_URL'], key, ...options })
     const transformedData = transformResponseData(data)
     return { data: transformedData, error }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import useImageUrl from '~~/composables/useImageUrl'
 
-const articlesPromise = findArticlePages('').then(({ data }) =>
+const articlesPromise = findArticlePages({}).then(({ data }) =>
   normalizeFindArticlePagesResponse(data)
 )
 


### PR DESCRIPTION
Nuxt does local caching (in memory until the browser refreshes the page) of all calls to `useFetch` which means that requests to the same resource with the same parameters are considered duplicate requests and the data is never updated. While this makes repeated navigations to the same page within a session feel really snappy, (e.g. when you click the back button, to go back to the homepage), it can mean that data gets stale when you stay on the site for too long.

This update adds a timestamp to the values used to compute the unique key for `useFetch`, forcing to always try to fetch new data, so that pages always show the latest stories.

-------

Right now it's just the brute force solution of refreshing every time but we can adjust this if it actually affects performance in practice.   For example, a simple way to include a throttle would be to divide (and round) the timestamp to reduce its precision (i.e. turn it into a timestamp only changes every minute or two).

We also have a parameter to turn it off (i.e. re-enable local caching) for specific requests if we need to further fine tune the refresh behavior.