### PR TITLE
Update height of top banner ad wrapper on desktop widths

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -227,8 +227,8 @@ watch(route, (value) => {
     z-index: 5000;
   }
   @include media('>=md') {
-    height: 306px;
-    padding: 28px auto;
+    height: 92px;
+    padding: 1px auto;
   }
 }
 


### PR DESCRIPTION
Making the top banner area smaller on desktop.

The new max ad height should be 90px but we're leaving a 92px area to leave a 1px black border for better separation of the ad and content

This update depends on some updates with adops/htl to actually reduce the size of ads before we can release.