### PR TITLE
Day of go live updates.

### DIFF
--- a/components/CommentsSection.vue
+++ b/components/CommentsSection.vue
@@ -16,7 +16,7 @@ const getArticleTagsString = () => {
 const getArticleUrl = () => {
   // force the data-post-url to match the beta.gothamist.com url of the article
   // TODO: REMOVE REPLACE WHEN WE GO LIVE
-  var url = props.article.url.replace('//gothamist.com', config.betaUrl)
+  var url = props.article.url
   return url
 }
 useHead({

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -211,4 +211,22 @@ http {
             return 200;
         }
     }
+    server {
+        listen       80;
+        server_name  www.gothamist.com gothamist-vue3.prod.nypr.digital;
+        resolver     172.16.0.2 valid=60s;
+
+        location / {
+            return 301 $scheme://gothamist.com$request_uri;
+        }
+    }
+    server {
+        listen       80;
+        server_name  beta.gothamist.com;
+        resolver     172.16.0.2 valid=60s;
+
+        location / {
+            return 302 $scheme://gothamist.com$request_uri;
+        }
+    }
 }


### PR DESCRIPTION
I've added some post launch redirects. I've removed the hard coded beta url outlined in  https://nypublicradio-digital.atlassian.net/browse/GOTH-471