### PR TITLE
Streamfield Image Caption Override fix

### DIFF
--- a/components/Streamfield/StreamfieldImage.vue
+++ b/components/Streamfield/StreamfieldImage.vue
@@ -14,7 +14,7 @@ defineProps<{
     :alt-text="block.value.image.alt"
     :maxWidth="block.value.image.width"
     :maxHeight="block.value.image.height"
-    :description="block.value.image.caption"
+    :description="block.value.caption || block.value.image.caption"
     :credit="`Photo by ${block.value.image.credit}`"
     :credit-url="block.value.image.creditLink"
     :sizes="[2]"

--- a/composables/types/StreamfieldBlock.ts
+++ b/composables/types/StreamfieldBlock.ts
@@ -34,7 +34,7 @@ export type HeadingBlock = {
 export type ImageBlock = {
     id: string;
     type: 'image';
-    value: { image: Image };  
+    value: { image: Image, caption: string };  
 }
 
 export type ParagraphBlock = {


### PR DESCRIPTION
added conditional to check override caption first in StreamfiledImages and updated the value object for ImageBlock type.

The caption override is outside the image object for some reason. 
![image](https://user-images.githubusercontent.com/13803343/194572360-b30cb595-1893-4f6a-ad89-6e566c877bfb.png)
