### PR TITLE
GOTH-498

### DIFF
--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -37,7 +37,6 @@ function replaceTweet(tweetId) {
             window.twttr.widgets.createTweet(tweetId, newTweetDiv, {theme: isDark.value ? 'dark' : 'light'})
             .then(createdTweet => {
                 if (createdTweet) {
-                    console.log('SUCCESS', tweetId)
                     originalTweetElement.parentNode.removeChild(originalTweetElement)
                 }
             })
@@ -50,7 +49,6 @@ function replaceTweet(tweetId) {
 onMounted(() => {
     el.value.innerHTML = stripTweetScripts(props.block.value.embed)
     if (window.twttr) {
-        console.log(tweetIds.value)
         const promises = tweetIds.value.map(id => {return replaceTweet(id)})
         Promise.all(promises)
     }

--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -34,10 +34,11 @@ function replaceTweet(tweetId) {
             const originalTweetElement = findTweetElement(tweetId)
             const newTweetDiv = document.createElement('DIV')
             originalTweetElement.parentNode.insertBefore(newTweetDiv, originalTweetElement)
+            originalTweetElement.parentNode.removeChild(originalTweetElement);
             window.twttr.widgets.createTweet(tweetId, newTweetDiv, {theme: isDark.value ? 'dark' : 'light'})
             .then(createdTweet => {
-                if (createdTweet) {
-                    originalTweetElement.parentNode.removeChild(originalTweetElement)
+                if (!createdTweet) {
+                    newTweetDiv.parentNode.insertBefore(originalTweetElement, newTweetDiv)
                 }
             })
             .catch(e => resolve(e))

--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -24,7 +24,7 @@ function stripTweetScripts(stringToStrip) {
 
 // find the blockquote element for an unexpanded tweet embed
 function findTweetElement(tweetId) {
-    return [...document.querySelectorAll('blockquote.twitter-tweet')].filter(tweet => tweet.outerHTML.includes(tweetId))[0]
+    return [...el.value.querySelectorAll('blockquote.twitter-tweet')].filter(tweet => tweet.outerHTML.includes(tweetId))[0]
 }
 
 // replace a tweet blockquote with the expanded embed
@@ -32,6 +32,10 @@ function replaceTweet(tweetId) {
     return new Promise((resolve) => {
         if (window.twttr) {
             const originalTweetElement = findTweetElement(tweetId)
+            if (!originalTweetElement) {
+               resolve('error finding tweet element')
+               return;
+            }
             const newTweetDiv = document.createElement('DIV')
             originalTweetElement.parentNode.insertBefore(newTweetDiv, originalTweetElement)
             originalTweetElement.parentNode.removeChild(originalTweetElement);
@@ -47,9 +51,10 @@ function replaceTweet(tweetId) {
     })
 }
 
-onMounted(() => {
+onMounted(async () => {
     el.value.innerHTML = stripTweetScripts(props.block.value.embed)
     if (window.twttr) {
+        await nextTick()
         const promises = tweetIds.value.map(id => {return replaceTweet(id)})
         Promise.all(promises)
     }

--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -32,7 +32,6 @@ function replaceTweet(tweetId) {
         const originalTweetElement = findTweetElement(tweetId)
         const newTweetDiv = document.createElement('DIV')
         originalTweetElement.parentNode.insertBefore(newTweetDiv, originalTweetElement)
-        console.log('TWET', tweetId, originalTweetElement)
         window.twttr.widgets.createTweet(tweetId, newTweetDiv, {theme: isDark.value ? 'dark' : 'light'})
         .then(createdTweet => {
             if (createdTweet) {

--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -9,7 +9,7 @@ const el = ref(null)
 
 const isDark = usePreferredDark()
 
-const tweetRegExp = /<blockquote class=\"twitter-tweet.*\/status\/(\d+)\?.*\/blockquote>/g
+const tweetRegExp = /<blockquote class="twitter-tweet.*\/status\/(\d+)\?.*\/blockquote>/g
 const tweetIds = computed(() => {
     return [...props.block.value.embed.matchAll(tweetRegExp)].map(matches => matches[1])
 })
@@ -17,7 +17,7 @@ const tweetIds = computed(() => {
 // Remove tweet scripts included with blocks in the cms payload so they can't
 // interfere, we're handling this manually
 function stripTweetScripts(stringToStrip) {
-    const tweetScriptMatcher = /<script*.src=\"https:\/\/platform.twitter.com\/widgets.js\" charset=\"utf-8\"><\/script>/g
+    const tweetScriptMatcher = /<script*.src=\"https:\/\/platform.twitter.com\/widgets.js" charset="utf-8"><\/script>/g
     return stringToStrip.replaceAll(tweetScriptMatcher, '')
 }
 

--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -18,7 +18,7 @@ const tweetIds = computed(() => {
 // Remove tweet scripts included with blocks in the cms payload so they can't
 // interfere, we're handling this manually
 function stripTweetScripts(stringToStrip) {
-    const tweetScriptMatcher = /<script.*?src="https:\/\/platform.twitter.com\/widgets.js" charset="utf-8"><\/script>/g
+    const tweetScriptMatcher = /<script async(="")? src="https:\/\/platform.twitter.com\/widgets.js" charset="utf-8"><\/script>/g
     return stringToStrip.replaceAll(tweetScriptMatcher, '')
 }
 


### PR DESCRIPTION
The old tweet embed code assumed each code or embed block with a tweet blockquote in it would be a tweet, but legacy articles are whole article html that can also just include tweets so it was just replacing them with the tweet.

The new code is a bit more complex, with weird regexps and dom selection stuff but should be less destructive.

1. strip the flaky twitter scripts that come with tweet embeds to prevent any weird race conditions or interference
2. find all the tweets
4. remove the original pre-expanded tweet blockquote, and only that (this helps prevent a duplicate in case the main twitter script sees this around and decides to handle it while we're waiting for the fancy embed)
5. create the fancy embeds using the twitter api script
6. if we fail to create a fancy embed re-add the original tweet