### PR TITLE
GOTH-496 Fix for legacy article layout

### DIFF
--- a/components/Streamfield/StreamfieldEmbedDefault.vue
+++ b/components/Streamfield/StreamfieldEmbedDefault.vue
@@ -9,7 +9,7 @@ const el = ref(null)
 
 <template>
   <div
-    class="streamfield-embed streamfield-embed-defualt mb-7"
+    class="streamfield-embed streamfield-embed-defualt streamfield-paragraph mb-7"
     v-html="block.value.embed"
     ref="el"
   />

--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -10,7 +10,7 @@ const el = ref(null)
 
 const isDark = usePreferredDark()
 
-const tweetRegExp = /<blockquote class="twitter-tweet.*?\/status\/(\d+)\?.*?\/blockquote>/g
+const tweetRegExp = /<blockquote class="twitter-tweet.*?\/status\/(\d+)?.*?\/blockquote>/g
 const tweetIds = computed(() => {
     return [...props.block.value.embed.matchAll(tweetRegExp)].map(matches => matches[1])
 })
@@ -63,7 +63,7 @@ onMounted(async () => {
 
 <template>
     <div
-    class="streamfield-embed streamfield-embed-tweet mb-7"
+    class="streamfield-embed streamfield-embed-tweet streamfield-paragraph mb-7"
     ref="el"
     />
 </template>

--- a/components/Streamfield/StreamfieldEmbedTweet.vue
+++ b/components/Streamfield/StreamfieldEmbedTweet.vue
@@ -10,15 +10,15 @@ const el = ref(null)
 
 const isDark = usePreferredDark()
 
-const tweetRegExp = /<blockquote class="twitter-tweet.*?\/status\/(\d+)?.*?\/blockquote>/g
+const tweetRegExp = /<blockquote class="twitter-tweet.*?\/status\/(?<id>\d+)?.*?\/blockquote>/g
 const tweetIds = computed(() => {
-    return [...props.block.value.embed.matchAll(tweetRegExp)].map(matches => matches[1])
+    return [...props.block.value.embed.matchAll(tweetRegExp)].map(match => match.groups?.id)
 })
 
 // Remove tweet scripts included with blocks in the cms payload so they can't
 // interfere, we're handling this manually
 function stripTweetScripts(stringToStrip) {
-    const tweetScriptMatcher = /<script async(="")? src="https:\/\/platform.twitter.com\/widgets.js" charset="utf-8"><\/script>/g
+    const tweetScriptMatcher = /<script async(?:="")? src="https:\/\/platform.twitter.com\/widgets.js" charset="utf-8"><\/script>/g
     return stringToStrip.replaceAll(tweetScriptMatcher, '')
 }
 


### PR DESCRIPTION
- add streamfield-paragraph class to embeds so legacy articles (which are just a block of embedded html) get all the nice text styles that regular articles do
- small tweak to the fix the tweet embed regex