### PR TITLE
GOTH-319 set up load more button

### DIFF
--- a/composables/useLoadMoreArticles.ts
+++ b/composables/useLoadMoreArticles.ts
@@ -1,0 +1,7 @@
+export default async function useLoadMoreArticles(options) {
+    const newArticles =  await findArticlePages(options).then(({ data }) =>
+        normalizeFindArticlePagesResponse(data)
+    )
+    useUpdateCommentCounts(newArticles)
+    return newArticles
+}

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -65,7 +65,7 @@ const newsletterSubmitEvent = () => {
             <div
               v-for="(article, index) in articles"
               :key="`${article.id}-${index}`"
-            >            
+            >
               <v-card
                 class="mod-horizontal mb-5"
                 :image="useImageUrl(article.listingImage)"

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -7,16 +7,29 @@ const { title: sectionTitle, id: sectionId } = await findPage(
   route?.params?.sectionSlug as string
 ).then(({ data }) => normalizeFindPageResponse(data))
 
-const articles = await findArticlePages({
+const initialStoryCount = ref(10)
+const loadMoreStoryCount = ref(10)
+const featuredStoryCount = ref(5)
+
+const initialArticles = await findArticlePages({
   descendant_of: sectionId,
-  offset: 5,
+  offset: featuredStoryCount.value,
 }).then(({ data }) => normalizeFindArticlePagesResponse(data))
-const articlesToShow = ref(6)
+const articles = ref(initialArticles)
+
+const loadMoreArticles = async () => {
+  const newArticles = await useLoadMoreArticles({
+    limit: loadMoreStoryCount.value,
+    offset: articles.value.length + featuredStoryCount.value,
+    descendant_of: sectionId,
+  })
+  articles.value.push(...newArticles)
+}
 
 const { $analytics } = useNuxtApp()
 onMounted(() => {
   $analytics.sendPageView({ page_type: 'section_page' })
-  useUpdateCommentCounts(articles)
+  useUpdateCommentCounts(articles.value)
 })
 
 const newsletterSubmitEvent = () => {
@@ -50,7 +63,7 @@ const newsletterSubmitEvent = () => {
           <div class="col-1 hidden xl:block"></div>
           <div class="col">
             <div
-              v-for="(article, index) in articles.slice(0, articlesToShow)"
+              v-for="(article, index) in articles"
               :key="`${article.id}-${index}`"
             >            
               <v-card
@@ -72,10 +85,9 @@ const newsletterSubmitEvent = () => {
               <hr class="mb-5" />
             </div>
             <Button
-              v-if="articlesToShow < articles.length"
               class="p-button-rounded mb-8"
               label="Load More"
-              @click="articlesToShow += 10"
+              @click="loadMoreArticles"
             >
             </Button>
           </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -130,7 +130,11 @@ const nativoSectionLoaded = (name) => {
         <template v-if="articles">
           <hr class="mb-4 black" />
           <div id="latest">
-            <div v-for="(riverSegment, segmentIndex) in riverSegments" class="grid gutter-x-xl">
+            <div
+              v-for="(riverSegment, segmentIndex) in riverSegments"
+              :key="riverSegment.map(article => article.uuid).join('-')"
+              class="grid gutter-x-xl"
+            >
               <div class="col-12 xxl:col-1 type-label3">{{segmentIndex === 0 ? "LATEST" : ""}}</div>
               <div class="col">
                 <div

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -46,6 +46,14 @@ const riverSegments = computed(() => {
   return segments
 })
 
+const loadMoreArticles = async () => {
+  const newArticles = await useLoadMoreArticles({
+    limit: riverStoryCount.value,
+    offset: latestArticles.value.length
+  })
+  latestArticles.value.push(...newArticles)
+}
+
 const { $analytics } = useNuxtApp()
 const newsletterSubmitEvent = () => {
   $analytics.sendEvent('click_tracking', {
@@ -76,15 +84,6 @@ const nativoSectionLoaded = (name) => {
     loadedNativoElements.length = 0
     PostRelease.Start()
   }
-}
-
-const loadMoreComments = async () => {
-  const limit = riverStoryCount.value
-  const offset = latestArticles.value.length
-  const newArticles =  await findArticlePages({limit, offset}).then(({ data }) =>
-    normalizeFindArticlePagesResponse(data)
-  )
-  latestArticles.value.push(...newArticles)
 }
 
 </script>
@@ -181,7 +180,7 @@ const loadMoreComments = async () => {
               <Button
                   class="p-button-rounded"
                   label="Load More"
-                  @click="loadMoreComments"
+                  @click="loadMoreArticles"
                 >
               </Button>
             </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -185,13 +185,16 @@ const nativoSectionLoaded = (name) => {
                 <HtlAd slot="htlad-gothamist_index_river" layout="rectangle" />
               </div>
             </div>
-            <div class="col col-12">
-              <Button
-                  class="p-button-rounded"
-                  label="Load More"
-                  @click="loadMoreArticles"
-                >
-              </Button>
+            <div class="grid gutter-x-xl">
+              <div class="col-12 xxl:col-1"></div>
+              <div class="col">
+                <Button
+                    class="p-button-rounded"
+                    label="Load More"
+                    @click="loadMoreArticles"
+                  >
+                </Button>
+              </div>
             </div>
           </div>
         </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -129,51 +129,56 @@ const nativoSectionLoaded = (name) => {
       <div class="content">
         <template v-if="articles">
           <hr class="mb-4 black" />
-          <div id="latest" class="grid gutter-x-xl">
-            <div class="col-12 xxl:col-1 type-label3">LATEST</div>
-            <div v-for="riverSegment in riverSegments" class="col col-12">
-              <div
-                v-for="(article, index) in riverSegment.slice(0, riverStoryCount)"
-                :key="article.uuid"
-              >
-                <v-card
-                  :id="index === 1 ? 'ntv-stream-3' : ''"
-                  class="mod-horizontal mb-3 lg:mb-5 tag-small"
-                  :image="useImageUrl(article.listingImage)"
-                  :width="318"
-                  :height="212"
-                  :sizes="[1]"
-                  :quality="80"
-                  :title="article.listingTitle"
-                  :titleLink="article.link"
-                  :maxWidth="article.image?.width"
-                  :maxHeight="article.image?.height"
-                  :tags="[
-                    {
-                      name: article.section.name,
-                      slug: `/${article.section.slug}`,
-                    },
-                  ]"
-                  @vue:mounted="
-                    index === 1 && nativoSectionLoaded('ntv-stream-3')
-                  "
-                >
-                  <p class="desc">
-                    {{ article.description }}
-                  </p>
-                  <v-card-metadata :article="article" />
-                </v-card>
-                <hr class="mb-5" />
+          <div id="latest">
+            <div v-for="(riverSegment, segmentIndex) in riverSegments" class="grid gutter-x-xl">
+              <div class="col-12 xxl:col-1 type-label3">{{segmentIndex === 0 ? "LATEST" : ""}}</div>
+              <div class="col">
                 <div
-                  v-if="(index + riverAdOffset) % riverAdRepeatRate === 0"
-                  class="xl:hidden"
+                  v-for="(article, itemIndex) in riverSegment.slice(0, riverStoryCount)"
+                  :key="article.uuid"
                 >
-                  <HtlAd
-                    slot="htlad-gothamist_index_river"
-                    layout="rectangle"
-                  />
+                  <v-card
+                    :id="itemIndex === 1 ? 'ntv-stream-3' : ''"
+                    class="mod-horizontal mb-3 lg:mb-5 tag-small"
+                    :image="useImageUrl(article.listingImage)"
+                    :width="318"
+                    :height="212"
+                    :sizes="[1]"
+                    :quality="80"
+                    :title="article.listingTitle"
+                    :titleLink="article.link"
+                    :maxWidth="article.image?.width"
+                    :maxHeight="article.image?.height"
+                    :tags="[
+                      {
+                        name: article.section.name,
+                        slug: `/${article.section.slug}`,
+                      },
+                    ]"
+                    @vue:mounted="
+                      itemIndex === 1 && nativoSectionLoaded('ntv-stream-3')
+                    "
+                  >
+                    <p class="desc">
+                      {{ article.description }}
+                    </p>
+                    <v-card-metadata :article="article" />
+                  </v-card>
                   <hr class="mb-5" />
+                  <div
+                    v-if="(itemIndex + riverAdOffset) % riverAdRepeatRate === 0"
+                    class="xl:hidden"
+                  >
+                    <HtlAd
+                      slot="htlad-gothamist_index_river"
+                      layout="rectangle"
+                    />
+                    <hr class="mb-5" />
+                  </div>
                 </div>
+              </div>
+              <div class="col-fixed hidden xl:block mx-auto">
+                <HtlAd slot="htlad-gothamist_index_river" layout="rectangle" />
               </div>
             </div>
             <div class="col col-12">
@@ -183,9 +188,6 @@ const nativoSectionLoaded = (name) => {
                   @click="loadMoreArticles"
                 >
               </Button>
-            </div>
-            <div class="col-fixed hidden xl:block mx-auto">
-              <HtlAd slot="htlad-gothamist_index_river" layout="rectangle" />
             </div>
           </div>
         </template>

--- a/pages/staff/[staffSlug].vue
+++ b/pages/staff/[staffSlug].vue
@@ -35,7 +35,7 @@ const loadMoreArticles = async () => {
 }
 
 // find a match of the slug in the articles' authors array and return the matched author's data
-const authorProfileData = articles[1]?.authors.find((author) => {
+const authorProfileData = articles.value[1]?.authors.find((author) => {
   if (author.slug === staffSlug) return author
 })
 


### PR DESCRIPTION
https://nypublicradio-digital.atlassian.net/browse/GOTH-319

- Make the "Load More" button on home page, tag pages, and section pages load more articles
- Also load comment counts when loading more articles
- On tag pages, hide the load more button when there are no more stories to load
- On the home page, insert new ad slots along with the newly added stories, on wide screens, these should show in the right column, but on mobile they're inline with the articles.