### PR TITLE
updated the gradient by removing all the dups and adding to default template

### DIFF
--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -20,6 +20,10 @@ body {
   height: 100vh;
 }
 
+@mixin page-top-gradient {
+  background: linear-gradient(180deg, #f3f3e4 0, rgba(255, 255, 255, 0) 720px, rgba(255, 255, 255, 0) 100%);
+}
+
 hr {
   border: 0;
   height: 1px;

--- a/components/HeaderScrollTrigger.vue
+++ b/components/HeaderScrollTrigger.vue
@@ -11,7 +11,7 @@ const props = defineProps({
   },
   triggerClass: {
     type: String,
-    default: 'main',
+    default: 'default-slot-holder',
   },
   isHidden: {
     type: Boolean,

--- a/error.vue
+++ b/error.vue
@@ -234,12 +234,7 @@ const newsletterSubmitEvent = () => {
 
 <style lang="scss">
 .error-page {
-  background: linear-gradient(
-    180deg,
-    #f3f3e4 0,
-    rgba(255, 255, 255, 0) 720px,
-    rgba(255, 255, 255, 0) 100%
-  );
+  @include page-top-gradient;
   .error-page-header {
     background: var(--soybean200);
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -221,24 +221,26 @@ watch(leaderboardAdToWatch.height, (height) => {
           slot="htlad-gothamist_interior_leaderboard_1"
         />
       </div>
-      <HeaderScrollTrigger :isHidden="isArticlePage">
+      <main class="main">
+        <HeaderScrollTrigger :isHidden="isArticlePage">
+          <GothamistMainHeader
+            class="fixed-header"
+            :navigation="navigation"
+            :isMinimized="true"
+            isFixed
+            :donateUrlBase="config.donateUrlBase"
+            utmCampaign="homepage-header"
+          />
+        </HeaderScrollTrigger>
         <GothamistMainHeader
-          class="fixed-header"
           :navigation="navigation"
-          :isMinimized="true"
-          isFixed
+          :isMinimized="route.name !== 'index'"
           :donateUrlBase="config.donateUrlBase"
           utmCampaign="homepage-header"
         />
-      </HeaderScrollTrigger>
-      <GothamistMainHeader
-        :navigation="navigation"
-        :isMinimized="route.name !== 'index'"
-        :donateUrlBase="config.donateUrlBase"
-        utmCampaign="homepage-header"
-      />
-      <main class="main">
-        <slot />
+        <div class="default-slot-holder">
+          <slot />
+        </div>
       </main>
       <gothamist-footer :navigation="navigation" />
       <audio-player />
@@ -300,6 +302,15 @@ watch(leaderboardAdToWatch.height, (height) => {
   @include media('>=md') {
     min-height: 92px;
     padding: 1px 0;
+  }
+}
+
+.main {
+  @include page-top-gradient;
+}
+.sectionSlug-photos-gallerySlug {
+  .main {
+    background: none;
   }
 }
 

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -249,12 +249,6 @@ const getGalleryLink = computed(() => {
 
 <style lang="scss">
 .page.sectionSlug-articleSlug {
-  background: linear-gradient(
-    180deg,
-    #f3f3e4 0,
-    rgba(255, 255, 255, 0) 720px,
-    rgba(255, 255, 255, 0) 100%
-  );
   .v-tag .p-button {
     background: transparent;
     &:hover {

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
-import { useUpdateCommentCounts } from '~~/composables/comments';
+import { useUpdateCommentCounts } from '~~/composables/comments'
 const route = useRoute()
 
 const { title: sectionTitle, id: sectionId } = await findPage(
@@ -106,14 +106,6 @@ const newsletterSubmitEvent = () => {
 </template>
 
 <style lang="scss">
-.page.sectionSlug {
-  background: linear-gradient(
-    180deg,
-    #f3f3e4 0,
-    rgba(255, 255, 255, 0) 720px,
-    rgba(255, 255, 255, 0) 100%
-  );
-}
 .section-page .v-card {
   background-color: transparent;
 }

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -43,14 +43,3 @@ const newsletterSubmitEvent = () => {
     </section>
   </div>
 </template>
-
-<style lang="scss">
-.page.contact {
-  background: linear-gradient(
-    180deg,
-    #f3f3e4 0,
-    rgba(255, 255, 255, 0) 720px,
-    rgba(255, 255, 255, 0) 100%
-  );
-}
-</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,17 +3,16 @@ import { onMounted } from 'vue'
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { useUpdateCommentCounts } from '~~/composables/comments'
 import useImageUrl from '~~/composables/useImageUrl'
-import { ArticlePage } from '~~/composables/types/Page';
+import { ArticlePage } from '~~/composables/types/Page'
 import { computed, ref } from 'vue'
 
 const riverStoryCount = ref(6)
 const riverAdOffset = ref(2)
 const riverAdRepeatRate = ref(6)
 
-const articlesPromise = findArticlePages({limit: riverStoryCount.value}).then(({ data }) =>
-  normalizeFindArticlePagesResponse(data)
+const articlesPromise = findArticlePages({ limit: riverStoryCount.value }).then(
+  ({ data }) => normalizeFindArticlePagesResponse(data)
 )
-
 
 const homePageCollectionsPromise = findPage('/').then(({ data }) => {
   return data.value.pageCollectionRelationship.map((collection) => {
@@ -49,7 +48,7 @@ const riverSegments = computed(() => {
 const loadMoreArticles = async () => {
   const newArticles = await useLoadMoreArticles({
     limit: riverStoryCount.value,
-    offset: latestArticles.value.length
+    offset: latestArticles.value.length,
   })
   latestArticles.value.push(...newArticles)
 }
@@ -85,7 +84,6 @@ const nativoSectionLoaded = (name) => {
     PostRelease.Start()
   }
 }
-
 </script>
 
 <template>
@@ -132,13 +130,18 @@ const nativoSectionLoaded = (name) => {
           <div id="latest">
             <div
               v-for="(riverSegment, segmentIndex) in riverSegments"
-              :key="riverSegment.map(article => article.uuid).join('-')"
+              :key="riverSegment.map((article) => article.uuid).join('-')"
               class="grid gutter-x-xl"
             >
-              <div class="col-12 xxl:col-1 type-label3">{{segmentIndex === 0 ? "LATEST" : ""}}</div>
+              <div class="col-12 xxl:col-1 type-label3">
+                {{ segmentIndex === 0 ? 'LATEST' : '' }}
+              </div>
               <div class="col">
                 <div
-                  v-for="(article, itemIndex) in riverSegment.slice(0, riverStoryCount)"
+                  v-for="(article, itemIndex) in riverSegment.slice(
+                    0,
+                    riverStoryCount
+                  )"
                   :key="article.uuid"
                 >
                   <v-card
@@ -189,10 +192,10 @@ const nativoSectionLoaded = (name) => {
               <div class="col-12 xxl:col-1"></div>
               <div class="col">
                 <Button
-                    class="p-button-rounded"
-                    label="Load More"
-                    @click="loadMoreArticles"
-                  >
+                  class="p-button-rounded"
+                  label="Load More"
+                  @click="loadMoreArticles"
+                >
                 </Button>
               </div>
             </div>
@@ -202,14 +205,3 @@ const nativoSectionLoaded = (name) => {
     </section>
   </div>
 </template>
-
-<style lang="scss">
-.page.index {
-  background: linear-gradient(
-    180deg,
-    #f3f3e4 0,
-    rgba(255, 255, 255, 0) 615px,
-    rgba(255, 255, 255, 0) 100%
-  );
-}
-</style>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -155,12 +155,6 @@ const newsletterSubmitEvent = () => {
 
 <style lang="scss">
 .search {
-  background: linear-gradient(
-    180deg,
-    #f3f3e4 0,
-    rgba(255, 255, 255, 0) 720px,
-    rgba(255, 255, 255, 0) 100%
-  );
   form {
     max-width: 894px;
     width: 100%;

--- a/pages/sponsored.vue
+++ b/pages/sponsored.vue
@@ -136,12 +136,6 @@ onUnmounted(() => {
 
 <style lang="scss">
 .page.sponsored {
-  background: linear-gradient(
-    180deg,
-    #f3f3e4 0,
-    rgba(255, 255, 255, 0) 720px,
-    rgba(255, 255, 255, 0) 100%
-  );
   .v-tag .p-button {
     background: transparent;
     &:hover {


### PR DESCRIPTION
the site had a bunch of duplicates of this gradient all over the place. I removed them all and created a mix-in on global.scss. in the default.vue file, I wrapped the <slot /> in a div and moved the header inside the <main/>. this now makes <main /> the starting point of the gradient directly below the ads. I include the mixin to <main/> and remove it on the photo gallery page.  I also updated the HeaderScrollTrigger to use the new slot wrapper div as the  default element to use. 