### PR TITLE
GOTH-489 Author bylines wrong when reloading page after publishing new story

### DIFF
--- a/composables/useAviary.ts
+++ b/composables/useAviary.ts
@@ -13,7 +13,7 @@ export default async function useAviary(path: string, options: Record<string, an
     // manually a generating fetch key here as a workaround for an issue in nuxt3 rc6
     // https://github.com/nuxt/framework/issues/5993
     const key = hash(['aviary', path, options, refreshTimestamp])
-    const { data, error } = await useFetch(path, { baseURL: config['API_URL'], key, ...options })
+    const { data, error } = await useFetch(path, { baseURL: config['API_URL'], key, initialCache: false, ...options })
     const transformedData = transformResponseData(data)
     return { data: transformedData, error }
 }


### PR DESCRIPTION
This is a weird one. Not sure why data appears to be persisting in nuxt across reloads or how author data is getting assigned to the wrong stories, but the issues appear to have something to do with nuxt's payload caching. The closest thing to documentation I can find for this feature appears here: https://github.com/nuxt/framework/pull/3985

setting `initalCache` to `false` with useFetch appears to solve the problem. Not sure if this will cause a noticable performance hit or extra traffic but I don't expect it to be an issue.

Note: This flag has been removed in the 3.0 release and the way the caching works has change, so updating to stable may also just fix our issues, but for now this seems to work. When we update we should try to remember to remove this flag from our requests though, since it does nothing in nuxt 3.0.
https://github.com/nuxt/framework/pull/8885