### PR TITLE
redirect beta-opt-in URLs to their target

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -145,6 +145,14 @@ http {
             return ngx.redirect("https://" .. ngx.var.host .. path, ngx.HTTP_MOVED_PERMANENTLY)
           }
         }
+
+        # delete "/beta-opt-in/?target=" from any URL (GOTH-540)
+        location ~ ^/beta-opt-in/?$ {
+            rewrite_by_lua_block {
+                local path = string.gsub(ngx.var.uri, '/beta-opt-in/?target=', '')
+                return ngx.redirect("https://" .. ngx.var.host .. path, ngx.HTTP_MOVED_PERMANENTLY)
+            }
+        }
          
         # site map
         location ~ "^/sitemap(-\w+)?\.xml$" {


### PR DESCRIPTION
Fix all the 501 errors being caused by /beta-opt-in/ URLs no longer working. Instead, 301-redirect them to their intended target.