### PR TITLE
Fix for comment count loading.

### DIFF
--- a/composables/comments.ts
+++ b/composables/comments.ts
@@ -5,7 +5,7 @@ import { ArticlePage } from './types/Page'
 export const useCommentCounts = () => useState<Record<string,number>>('commentCounts', () => ({}))
 
 // Gets comment counts for a list of comment ids
-export const useFetchCommentCounts = async function(commentIds:string[]):Promise<Record<string,number>> {
+const fetchCommentCounts = async function(commentIds:string[]):Promise<Record<string,number>> {
     const config = useRuntimeConfig()
     const baseURL = 'https://open-api.spot.im'
     const path = '/v1/messages-count'
@@ -37,7 +37,7 @@ export const useFetchCommentCounts = async function(commentIds:string[]):Promise
 export const useUpdateCommentCounts = async function(articles:ArticlePage[]) {
     const commentCounts = useCommentCounts()
     const commentIds = articles.map(article => String(article.legacyId || article.uuid))
-    const commentCountData = await useFetchCommentCounts(commentIds)
+    const commentCountData = await fetchCommentCounts(commentIds)
     Object.entries(commentCountData).forEach(([key, value]) => {
         commentCounts.value[key] = value
     })

--- a/composables/comments.ts
+++ b/composables/comments.ts
@@ -1,4 +1,3 @@
-import { hash } from 'ohash'
 import { ArticlePage } from './types/Page'
 
 // State to track the map of article ids to comment counts

--- a/composables/comments.ts
+++ b/composables/comments.ts
@@ -21,13 +21,11 @@ export const useFetchCommentCounts = async function(commentIds:string[]):Promise
                 "posts_ids": idList            
             }
         }
-        const key = hash(['comments', path, options, Number(new Date())])
-        requests.push(useFetch(path, {baseURL, key, ...options})) 
+        requests.push($fetch(path, {baseURL, ...options}))
     }
     const responses = await Promise.all(requests)
     responses.forEach(response => {
-        const data = response.data;
-        const messageCounts = data.value ? Object.entries(data.value["messages_count"]) : []
+        const messageCounts = response ? Object.entries(response["messages_count"]) : []
         messageCounts.forEach(([key, value]) => {
             counts[key] = value
         })


### PR DESCRIPTION
Comment counts weren't loading on the initial page load. It's hard to find a good explanation of this this in the documentation but apparently you should only use `useFetch` directly in the `setup` function of a component/page or in the lifecycle hooks (e.g. `onMounted`), or within a method that's directly called by that setup function. Otherwise you should use `$fetch` instead. 

`useFetch` is kind of designed to happen along with page/component loading (or along with a lifecycle hook) and when it's a few steps removed from that (such as in nested async calls) it can behave a little funny.

In this case, `useFetch` was being used asynchronously within another composable. Replaced it with `$fetch` and seems to be behaving as expected now.