### PR TITLE
GOTH-554 Sponsored content updates

### DIFF
--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -22,6 +22,7 @@ const { title: sectionTitle, id: sectionId } = await findPage(
 ).then(({ data }) => normalizeFindPageResponse(data))
 
 const articles = await findArticlePages({
+  sponsored_content: false,
   descendant_of: sectionId,
   limit: 6,
 }).then(({ data }) => normalizeFindArticlePagesResponse(data))

--- a/components/ArticleRecirculation.vue
+++ b/components/ArticleRecirculation.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useUpdateCommentCounts } from '~~/composables/comments';
 
@@ -51,16 +50,12 @@ onMounted(async () => {
     <div v-if="articles" class="recirculation">
       <div class="grid gutter-x-30">
         <div class="col-12 xl:col-8">
-          <v-card
+          <gothamist-card
+            :article="articleLg"
             class="article-lg mod-vertical mod-featured2 mod-large mb-4"
-            :image="useImageUrl(articleLg?.listingImage)"
-            :sizes="[1]"
             :width="897"
             :height="598"
-            :title="articleLg?.listingTitle"
-            :titleLink="articleLg?.link"
-            :maxWidth="articleLg?.listingImage?.width"
-            :maxHeight="articleLg?.listingImage?.height"
+            :hideTags="true"
             loading="eager"
           >
             <v-card-metadata
@@ -68,59 +63,50 @@ onMounted(async () => {
               altDesign
               :article="articleLg"
             />
-          </v-card>
+          </gothamist-card>
           <hr class="block xl:hidden mb-3" />
         </div>
         <div class="col-12 xl:col-4">
           <!-- md article desktop  -->
-          <v-card
+          <gothamist-card
+            :article="articleMd"
             class="hidden xl:flex article-md mod-vertical mod-large mb-5"
-            :image="useImageUrl(articleMd?.listingImage)"
-            :title="articleMd?.listingTitle"
-            :titleLink="articleMd?.link"
-            :ratio="[3, 2]"
             :width="433"
             :height="289"
-            :sizes="[1]"
-            :maxWidth="articleMd?.listingImage?.width"
-            :maxHeight="articleMd?.listingImage?.height"
+            :hideTags="true"
             loading="eager"
           >
             <p>
               {{ articleMd?.description }}
             </p>
             <v-card-metadata stack :article="articleMd" />
-          </v-card>
+          </gothamist-card>
           <!-- md article mobile  -->
-          <v-card
+          <gothamist-card
+            :article="articleMd"
             class="flex xl:hidden article-md mod-horizontal mod-left tag-small mb-5"
-            :image="useImageUrl(articleMd?.listingImage)"
-            :title="articleMd?.listingTitle"
-            :titleLink="articleMd?.link"
             :width="318"
             :height="212"
-            :sizes="[1]"
-            :maxWidth="articleMd?.listingImage?.width"
-            :maxHeight="articleMd?.listingImage?.height"
             loading="eager"
           >
             <p>
               {{ articleMd?.description }}
             </p>
             <v-card-metadata :article="articleMd" />
-          </v-card>
+          </gothamist-card>
           <hr class="my-3" />
           <horizontal-drag :articles="articlesSm" v-slot="slotProps">
-            <v-card
+            <gothamist-card
+              :article="slotProps.article"
               class="article-sm mod-horizontal mod-small mb-3 tag-small"
-              :title="slotProps.article.listingTitle"
-              :titleLink="slotProps.article.link"
+              :hide-image="true"
+              :hide-tags="true"
             >
               <v-card-metadata
                 :article="slotProps.article"
                 :showComments="true"
               />
-            </v-card>
+            </gothamist-card>
           </horizontal-drag>
         </div>
       </div>

--- a/components/CenterFeature.vue
+++ b/components/CenterFeature.vue
@@ -82,6 +82,7 @@ const articlesSm = ref([
             :width="106"
             :height="106"
             :ratio="[1, 1]"
+            :hide-tags="true"
             :sizes="[2]"
           >
             <div></div>

--- a/components/CenterFeature.vue
+++ b/components/CenterFeature.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { ref } from 'vue'
 
 const props = defineProps({
@@ -30,107 +29,67 @@ const articlesSm = ref([
     <div class="grid gutter-x-30">
       <div class="col-fixed flex-order-2 lg:flex-order-1">
         <!-- md article desktop  -->
-        <v-card
+        <gothamist-card
+          :article="articleMd"
           class="hidden lg:flex article-md mod-vertical mod-large mb-5 tag-small"
-          :image="useImageUrl(articleMd.listingImage)"
-          :title="articleMd.listingTitle"
-          :titleLink="articleMd.link"
-          :ratio="[3, 2]"
           :width="433"
           :height="289"
-          :sizes="[1]"
-          :maxWidth="articleMd.listingImage?.width"
-          :maxHeight="articleMd.listingImage?.height"
           loading="eager"
-          :tags="[
-            {
-              name: articleMd.section.name,
-              slug: `/${articleMd.section.slug}`,
-            },
-          ]"
         >
           <p>
             {{ articleMd.description }}
           </p>
           <v-card-metadata stack :article="articleMd" />
-        </v-card>
+        </gothamist-card>
         <!-- md article mobile  -->
-        <v-card
+        <gothamist-card
+          :article="articleMd"
           class="flex lg:hidden article-md mod-horizontal mod-left tag-small"
-          :image="useImageUrl(articleMd.listingImage)"
-          :title="articleMd.listingTitle"
-          :titleLink="articleMd.link"
           :width="318"
           :height="212"
-          :sizes="[1]"
-          :maxWidth="articleMd.listingImage?.width"
-          :maxHeight="articleMd.listingImage?.height"
-          loading="lazy"
-          :tags="[
-            {
-              name: articleMd.section.name,
-              slug: `/${articleMd.section.slug}`,
-            },
-          ]"
         >
           <p>
             {{ articleMd.description }}
           </p>
           <v-card-metadata :article="articleMd" />
-        </v-card>
+        </gothamist-card>
         <div class="hidden lg:block mb-4 xl:mb-7">
           <HtlAd layout="rectangle" slot="htlad-gothamist_index_topper" />
         </div>
       </div>
       <div class="col flex-order-1 lg:flex-order-2">
-        <v-card
+        <gothamist-card
+          :article="articleLg"
           class="article-lg mod-vertical mod-large mb-4"
           :image="useImageUrl(articleLg.listingImage)"
-          :sizes="[1]"
           :width="700"
           :height="467"
-          :title="articleLg.listingTitle"
-          :titleLink="articleLg.link"
-          :maxWidth="articleLg.listingImage?.width"
-          :maxHeight="articleLg.listingImage?.height"
-          loading="lazy"
-          :tags="[
-            {
-              name: articleLg.section.name,
-              slug: `/${articleLg.section.slug}`,
-            },
-          ]"
         >
           <v-card-metadata
             class="mt-0 md:mt-2"
             altDesign
             :article="articleLg"
           />
-        </v-card>
+        </gothamist-card>
         <hr class="block lg:hidden mb-3" />
       </div>
       <div class="col-3 flex-order-3">
         <hr class="my-3 block xl:hidden" />
         <horizontal-drag :articles="articlesSm" v-slot="slotProps">
-          <v-card
+          <gothamist-card
+            :article="slotProps.article"
             class="mod-horizontal mod-left mod-small mb-0"
-            :image="useImageUrl(slotProps.article.listingImage)"
             :width="106"
             :height="106"
             :ratio="[1, 1]"
             :sizes="[2]"
-            :title="slotProps.article.listingTitle || slotProps.article.title"
-            :titleLink="slotProps.article.link"
-            :maxWidth="slotProps.article.listingImage?.width"
-            :maxHeight="slotProps.article.listingImage?.height"
-            :quality="80"
           >
             <div></div>
             <v-card-metadata
               :article="slotProps.article"
               :showComments="false"
             />
-          </v-card>
+          </gothamist-card>
         </horizontal-drag>
         <div class="block lg:hidden mb-4 xl:mb-7 m-auto mt-6">
           <HtlAd layout="rectangle" slot="htlad-gothamist_index_topper" />

--- a/components/ContentCollection.vue
+++ b/components/ContentCollection.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
 import { ArticlePage } from '../composables/types/Page'
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
-import VByline from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VByline.vue'
-import useImageUrl from '~~/composables/useImageUrl'
 
-const props = defineProps({
-  articles: {
-    type: Array,
-    default: [],
-  },
+const props = withDefaults(defineProps<{
+  articles?: ArticlePage[]
+}>(), {
+  articles: () => []
 })
 
 const articleData = []
@@ -25,22 +21,18 @@ props.articles.forEach((article) => {
         :key="article.uuid"
         class="col-12 md:col-6 xl:col-4 flex"
       >
-        <v-card
+        <gothamist-card
+          :article="article"
           class="mod-vertical mod-large mb-3 lg:mb-5 tag-small"
-          :image="useImageUrl(article.listingImage)"
           :width="318"
           :height="212"
           :sizes="[1]"
-          :title="article.listingTitle || article.title"
-          :titleLink="article.link"
-          :maxWidth="article.listingImage?.width"
-          :maxHeight="article.listingImage?.height"
         >
           <p class="desc">
             {{ article.description }}
           </p>
           <v-card-metadata :article="article" />
-        </v-card>
+        </gothamist-card>
         <hr class="mb-5 block md:hidden" />
       </div>
     </div>

--- a/components/GothamistCard.vue
+++ b/components/GothamistCard.vue
@@ -39,6 +39,7 @@ const tags = computed(() => {
 
 <template>
     <v-card
+        class="gothamist-card"
         :class="props.class"
         :image="hideImage ? null : useImageUrl(article.listingImage)"
         :title="article.listingTitle"
@@ -58,3 +59,19 @@ const tags = computed(() => {
         <slot />
     </v-card>
 </template>
+
+<style lang="scss">
+div.gothamist-card.sponsored {
+    background: var(--soybean200)
+}
+@include media('<lg') {
+    div.gothamist-card.sponsored.mod-horizontal {
+        min-width: 100vw;
+        padding: 0 1.5rem;
+        margin-left: -1.5rem;
+        & .image-with-caption {
+            margin: 2rem 0;
+        }
+    }
+}
+</style>

--- a/components/GothamistCard.vue
+++ b/components/GothamistCard.vue
@@ -39,7 +39,7 @@ const tags = computed(() => {
 
 <template>
     <v-card
-        :class="class"
+        :class="props.class"
         :image="hideImage ? null : useImageUrl(article.listingImage)"
         :title="article.listingTitle"
         :titleLink="article.link"

--- a/components/GothamistCard.vue
+++ b/components/GothamistCard.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ArticlePage } from '~~/composables/types/Page';
+import { computed } from 'vue';
+import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
+const props = withDefaults(defineProps<{ 
+    article: ArticlePage
+    class: string
+    width?: number
+    height?: number
+    ratio?: number[]
+    sizes?: number[]
+    quality?: number
+    hideImage?: boolean
+    hideTags?: boolean
+    loading?: 'eager' | 'lazy'
+}>(), {
+    width: null,
+    height: null,
+    ratio: () => [3, 2],
+    sizes: () => [1],
+    hideImage: false,
+    hideTags: false,
+    quality: 80,
+    loading: 'lazy'
+})
+
+const tags = computed(() => {
+    if (props.hideTags || props.article.sponsoredContent) {
+        return []
+    }
+    return [
+        {
+            name: props.article.section.name,
+            slug: `/${props.article.section.slug}`
+        }
+    ]
+})
+</script>
+
+<template>
+    <v-card
+        :class="class"
+        :image="hideImage ? null : useImageUrl(article.listingImage)"
+        :title="article.listingTitle"
+        :titleLink="article.link"
+        :maxWidth="article.listingImage?.width"
+        :maxHeight="article.listingImage?.height"
+        :sponsored="article.sponsoredContent"
+        :ratio="ratio"
+        :width="width"
+        :height="height"
+        :sizes="sizes"
+        :quality="80"
+        :tags="tags"
+        :loading="loading"
+        v-bind="{ ...$props, ...$attrs }"
+    >
+        <slot />
+    </v-card>
+</template>

--- a/components/GothamistHomepageTopper.vue
+++ b/components/GothamistHomepageTopper.vue
@@ -27,26 +27,15 @@ const latestArticles = computed(() => {
 <template v-if="featuredArticle && latestArticles">
   <div class="homepage-topper grid mb-6 gutter-x-30">
     <div class="col-12 xl:col-8">
-      <v-card
+      <gothamist-card
+        :article="featuredArticle"
         class="featured-article mod-vertical mod-featured mod-large"
-        :image="useImageUrl(featuredArticle.listingImage)"
-        :sizes="[1]"
         :width="897"
         :height="598"
-        :title="featuredArticle.listingTitle || featuredArticle.title"
-        :titleLink="featuredArticle.link"
-        :maxWidth="featuredArticle.listingImage?.width"
-        :maxHeight="featuredArticle.listingImage?.height"
-        :tags="[
-          {
-            name: featuredArticle.section.name,
-            slug: `/${featuredArticle.section.slug}`,
-          },
-        ]"
         loading="eager"
       >
         <v-card-metadata altDesign :article="featuredArticle" />
-      </v-card>
+      </gothamist-card>
     </div>
     <div class="col-12 xl:col-4 flex flex-column justify-content-end">
       <hr class="black mb-1" />
@@ -59,22 +48,18 @@ const latestArticles = computed(() => {
         />
       </v-flexible-link>
       <div v-for="(article, index) in latestArticles" :key="article.uuid">
-        <v-card
+        <gothamist-card
+          :article="article"
           :id="index === 3 ? 'ntv-latest-1' : ''"
           class="mod-horizontal mod-left mod-small mb-3 tag-small"
-          :image="useImageUrl(article.listingImage)"
           :width="158"
           :height="105"
           :sizes="[2]"
-          :title="article.listingTitle || article.title"
-          :titleLink="article.link"
-          :maxWidth="article.listingImage?.width"
-          :maxHeight="article.listingImage?.height"
-          :quality="80"
+          :hide-tags="true"
         >
           <div></div>
           <v-card-metadata :article="article" :showComments="false" />
-        </v-card>
+        </gothamist-card>
         <hr class="my-3 block" />
       </div>
       <div class="mb-1">

--- a/components/SingleStoryFeature.vue
+++ b/components/SingleStoryFeature.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
+
 const props = defineProps({
   collection: {
     type: Object,
@@ -13,27 +13,16 @@ const article = normalizeArticlePage(props.collection.data[0])
 </script>
 
 <template>
-  <v-card
+  <gothamist-card
+    :article="article"
     v-if="article"
     class="mod-large mb-5 lg:mb-8 tag-small single-story-feature"
     data-style-mode="dark"
-    :image="useImageUrl(article.listingImage)"
-    :ratio="[3, 2]"
     :sizes="[2]"
-    :title="article.listingTitle"
-    :titleLink="article.link"
-    :maxWidth="article.listingImage?.width"
-    :maxHeight="article.listingImage?.height"
-    :tags="[
-      {
-        name: article.section.name,
-        slug: article.section.slug,
-      },
-    ]"
   >
     <p class="desc">{{ article.description }}</p>
     <v-card-metadata :article="article" alt-design :show-description="false" />
-  </v-card>
+  </gothamist-card>
 </template>
 
 <style lang="scss">

--- a/components/SkylineFeature.vue
+++ b/components/SkylineFeature.vue
@@ -1,5 +1,4 @@
 <script setup>
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { useBreakpoints } from '@vueuse/core'
 import breakpoint from '@nypublicradio/nypr-design-system-vue3/src/assets/library/breakpoints.module.scss'
 import { ref } from 'vue'
@@ -51,23 +50,12 @@ const isOneOnly = !articleMd.value && !articleSm.value
           class="col-12 lg:col-12 flex-order-0 xl:flex-order-3"
           :class="isOneOnly ? 'xl:col-12' : 'xl:col-6'"
         >
-          <v-card
+          <gothamist-card
+            :article="articleLg"
             class="primary article-lg mod-vertical mod-featured2 mod-large mb-4"
-            :image="useImageUrl(articleLg?.listingImage)"
-            :sizes="[1]"
-            :ratio="isOneOnly ? [6, 2] : [3, 2]"
             :width="isOneOnly ? 1360 : 665"
             :height="isOneOnly ? 453 : 443"
-            :title="articleLg?.listingTitle"
-            :titleLink="articleLg?.link"
-            :maxWidth="articleLg?.listingImage?.width"
-            :maxHeight="articleLg?.listingImage?.height"
-            :tags="[
-              {
-                name: articleLg?.section.name,
-                slug: `/${articleLg?.section.slug}`,
-              },
-            ]"
+            :ratio="isOneOnly ? [6, 2] : [3, 2]"
             loading="eager"
           >
             <v-card-metadata
@@ -75,8 +63,7 @@ const isOneOnly = !articleMd.value && !articleSm.value
               altDesign
               :article="articleLg"
             />
-          </v-card>
-          <!-- <hr class="block xl:hidden mb-3" /> -->
+          </gothamist-card>
         </div>
         <!-- need to wrap in ClientOnly for breakpoint to initially work -->
         <ClientOnly>
@@ -85,71 +72,47 @@ const isOneOnly = !articleMd.value && !articleSm.value
             class="col-12 md:col-6 xl:col-3 flex-order-1 lg:flex-order-0"
           >
             <!-- md article desktop  -->
-            <v-card
+            <gothamist-card
+              :article="articleMd"
               class="secondary article-md mb-5 tag-small"
               :class="
                 smallerThanMd
                   ? 'mod-horizontal mod-left'
                   : 'mod-vertical mod-large'
               "
-              :image="useImageUrl(articleMd?.listingImage)"
-              :title="articleMd?.listingTitle"
-              :titleLink="articleMd?.link"
-              :ratio="[1, 1]"
               :width="318"
               :height="318"
-              :sizes="[1]"
-              :maxWidth="articleMd?.listingImage?.width"
-              :maxHeight="articleMd?.listingImage?.height"
-              :tags="[
-                {
-                  name: articleMd?.section.name,
-                  slug: `/${articleMd?.section.slug}`,
-                },
-              ]"
+              :ratio="[1, 1]"
               loading="eager"
             >
               <p>
                 {{ articleMd?.description }}
               </p>
               <v-card-metadata stack :article="articleMd" />
-            </v-card>
+            </gothamist-card>
           </div>
           <div
             v-if="articleSm"
             class="col-12 md:col-6 xl:col-3 flex-order-2 lg:flex-order-1"
           >
             <!-- sm article desktop  -->
-
-            <v-card
+            <gothamist-card
+              :article="articleSm"
               class="secondary article-sm mb-5 tag-small secondary"
               :class="
                 smallerThanMd
                   ? 'mod-horizontal mod-left'
                   : 'mod-vertical mod-large'
               "
-              :image="useImageUrl(articleSm?.listingImage)"
-              :title="articleSm?.listingTitle"
-              :titleLink="articleSm?.link"
-              :ratio="[3, 2]"
               :width="318"
               :height="212"
-              :sizes="[1]"
-              :maxWidth="articleSm?.listingImage?.width"
-              :maxHeight="articleSm?.listingImage?.height"
-              :tags="[
-                {
-                  name: articleSm?.section.name,
-                  slug: `/${articleSm?.section.slug}`,
-                },
-              ]"
               loading="eager"
             >
               <p>
                 {{ articleSm?.description }}
               </p>
               <v-card-metadata stack :article="articleSm" />
-            </v-card>
+            </gothamist-card>
           </div>
         </ClientOnly>
       </div>

--- a/composables/data/articlePages.ts
+++ b/composables/data/articlePages.ts
@@ -127,6 +127,7 @@ export function normalizeSearchResults(results: Record<string, any>): ArticlePag
         sensitiveContent: results.result.sensitiveContent,
         provocativeContent: results.result.provocativeContent,
         sponsoredContent: results.result.sponsoredContent,
+        relatedLinks: results.result.relatedLinks,
         tags: results.result.tags,
         url: results.result.url,
         uuid: results.result.uuid,

--- a/composables/metadata.ts
+++ b/composables/metadata.ts
@@ -142,6 +142,9 @@ import { ArticlePage, GalleryPage } from './types/Page'
     const config = useRuntimeConfig()
     const metadata = {
       title: `${article.seoTitle} - Gothamist`,
+      link: [
+        {rel: 'canonical', href: article?.url}
+      ],
       meta: [
         { property: 'og:title', content: article.socialTitle },
         { property: 'og:description', content: article.socialDescription },

--- a/composables/metadata.ts
+++ b/composables/metadata.ts
@@ -164,6 +164,11 @@ import { ArticlePage, GalleryPage } from './types/Page'
     for (const author of article.authors) {
       metadata.meta.push( { name: 'article:author', content: `https://gothamist.com${author.url}` })
     }
+    if (article.sponsoredContent) {
+      metadata.meta.push({
+        name: 'robots', content: 'noindex,nofollow'
+      })
+    }
     return metadata
   }
 

--- a/composables/types/Page.ts
+++ b/composables/types/Page.ts
@@ -5,6 +5,8 @@ import Image from './Image';
 import Slide from './Slide';
 import Sponsor from './Sponsor';
 import Tag from './Tag';
+import NavigationLink from './NavigationLink'
+
 
 export interface Page {
     id: number;
@@ -41,7 +43,7 @@ export interface ArticlePage extends Page {
     sensitiveContent: boolean;
     provocativeContent: boolean;
     sponsoredContent: boolean;
-    relatedLinks: any[];
+    relatedLinks: NavigationLink[];
     tags: Tag[];
     url: string;
     uuid: string;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,7 +39,7 @@ const [navigation, breakingNews, productBanners] = await Promise.all([
   productBannersPromise,
 ])
 marketingBannerData.value = productBanners
-const isSponsored = route.name === 'sponsored'
+const isSponsoredRoute = route.name === 'sponsored'
 const strapline = useStrapline()
 const sensitiveContent = useSensitiveContent()
 const sidebarOpen = useSidebarIsOpen()
@@ -161,10 +161,10 @@ useHead({
     height=&quot;0&quot; width=&quot;0&quot; style=&quot;display:none;visibility:hidden&quot;></iframe>`
   }]
 })
-if (isSponsored) {
+if (isSponsoredRoute) {
   useHead({
     meta: [
-      {name: 'Googlebot-News', content:'noindex, nofollow'}
+      {name: 'robots', content:'noindex,nofollow'}
     ]
   })
 } else {

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -116,12 +116,8 @@ const showMarketingBanner = computed(() => {
   )
 })
 </script>
-
 <template>
   <div>
-    <Head>
-      <Link rel="canonical" v-if="article" :href="article.url" />
-    </Head>
     <HeaderScrollTrigger header-class="article-page-header">
       <ScrollTracker scrollTarget=".article-body" v-slot="scrollTrackerProps">
         <ArticlePageHeader

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -12,6 +12,7 @@ const loadMoreStoryCount = ref(10)
 const featuredStoryCount = ref(5)
 
 const initialArticles = await findArticlePages({
+  sponsored_content: false,
   descendant_of: sectionId,
   offset: featuredStoryCount.value,
 }).then(({ data }) => normalizeFindArticlePagesResponse(data))
@@ -19,6 +20,7 @@ const articles = ref(initialArticles)
 
 const loadMoreArticles = async () => {
   const newArticles = await useLoadMoreArticles({
+    sponsored_content: false,
     limit: loadMoreStoryCount.value,
     offset: articles.value.length + featuredStoryCount.value,
     descendant_of: sectionId,

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -72,23 +72,17 @@ useHead({
               v-for="(article, index) in articles"
               :key="`${article.id}-${index}`"
             >
-              <v-card
+              <gothamist-card
+                :article="article"
                 class="mod-horizontal mb-5"
-                :image="useImageUrl(article.listingImage)"
-                :title="article.listingTitle"
-                :titleLink="article.link"
-                :ratio="[3, 2]"
                 :width="318"
                 :height="212"
-                :maxWidth="article.listingImage?.width"
-                :maxHeight="article.listingImage?.height"
-                :sizes="[1]"
               >
                 <p>
                   {{ article.description }}
                 </p>
                 <v-card-metadata :article="article" />
-              </v-card>
+              </gothamist-card>
               <hr class="mb-5" />
             </div>
             <Button

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { useUpdateCommentCounts } from '~~/composables/comments'
 import useImageUrl from '~~/composables/useImageUrl'
 import { ArticlePage } from '~~/composables/types/Page'
@@ -150,24 +149,12 @@ const nativoSectionLoaded = (name) => {
                   )"
                   :key="article.uuid"
                 >
-                  <v-card
+                  <gothamist-card
+                    :article="article"
                     :id="itemIndex === 1 ? 'ntv-stream-3' : ''"
                     class="mod-horizontal mb-3 lg:mb-5 tag-small"
-                    :image="useImageUrl(article.listingImage)"
                     :width="318"
                     :height="212"
-                    :sizes="[1]"
-                    :quality="80"
-                    :title="article.listingTitle"
-                    :titleLink="article.link"
-                    :maxWidth="article.image?.width"
-                    :maxHeight="article.image?.height"
-                    :tags="[
-                      {
-                        name: article.section.name,
-                        slug: `/${article.section.slug}`,
-                      },
-                    ]"
                     @vue:mounted="
                       itemIndex === 1 && nativoSectionLoaded('ntv-stream-3')
                     "
@@ -176,7 +163,7 @@ const nativoSectionLoaded = (name) => {
                       {{ article.description }}
                     </p>
                     <v-card-metadata :article="article" />
-                  </v-card>
+                  </gothamist-card>
                   <hr class="mb-5" />
                   <div
                     v-if="(itemIndex + riverAdOffset) % riverAdRepeatRate === 0"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,7 +9,10 @@ const riverStoryCount = ref(6)
 const riverAdOffset = ref(2)
 const riverAdRepeatRate = ref(6)
 
-const articlesPromise = findArticlePages({ limit: riverStoryCount.value }).then(
+const articlesPromise = findArticlePages({
+  limit: riverStoryCount.value,
+  sponsored_content: false
+}).then(
   ({ data }) => normalizeFindArticlePagesResponse(data)
 )
 
@@ -45,6 +48,7 @@ const riverSegments = computed(() => {
 
 const loadMoreArticles = async () => {
   const newArticles = await useLoadMoreArticles({
+    sponsored_content: false,
     limit: riverStoryCount.value,
     offset: latestArticles.value.length,
   })

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -101,29 +101,17 @@ const newsletterSubmitEvent = () => {
                   v-for="article in articles.slice(0, articlesToShow)"
                   :key="article.uuid"
                 >
-                  <v-card
+                  <gothamist-card
+                    :article="article"
                     class="mod-horizontal mb-3 lg:mb-5 tag-small"
-                    :image="useImageUrl(article.listingImage)"
                     :width="318"
                     :height="212"
-                    :sizes="[1]"
-                    :quality="80"
-                    :title="article.listingTitle || article.title"
-                    :titleLink="article.link"
-                    :maxWidth="article.image?.width"
-                    :maxHeight="article.image?.height"
-                    :tags="[
-                      {
-                        name: article.section.name,
-                        slug: `/${article.section.slug}`,
-                      },
-                    ]"
                   >
                     <p class="desc">
                       {{ article.description }}
                     </p>
                     <v-card-metadata :article="article" />
-                  </v-card>
+                  </gothamist-card>
                   <hr class="mb-5" />
                 </div>
                 <Button

--- a/pages/staff/[staffSlug].vue
+++ b/pages/staff/[staffSlug].vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 //import { StaffPage } from '../../composables/types/Page'
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
-import VByline from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VByline.vue'
 
 const { $analytics, $htlbid } = useNuxtApp()
 const route = useRoute()
@@ -100,29 +98,17 @@ useHead({
               v-for="article in articles"
               :key="article.uuid"
             >
-              <v-card
+              <gothamist-card
+                :article="article"
                 class="mod-horizontal mb-5"
-                :image="useImageUrl(article.listingImage)"
-                :title="article.listingTitle || article.title"
-                :titleLink="article.link"
-                :ratio="[3, 2]"
                 :width="318"
                 :height="212"
-                :maxWidth="article.listingImage?.width"
-                :maxHeight="article.listingImage?.height"
-                :sizes="[1]"
-                :tags="[
-                  {
-                    name: article.section.name,
-                    slug: `/${article.section.slug}`,
-                  },
-                ]"
               >
                 <p>
                   {{ article.description }}
                 </p>
                 <v-card-metadata :article="article" />
-              </v-card>
+              </gothamist-card>
               <hr class="mb-5" />
             </div>
           </div>

--- a/pages/tags/[tagSlug].vue
+++ b/pages/tags/[tagSlug].vue
@@ -2,7 +2,6 @@
 import { TagPage } from '../../composables/types/Page'
 import { StreamfieldBlock, ContentCollectionBlock } from '../../composables/types/StreamfieldBlock'
 import { useUpdateCommentCounts } from '~~/composables/comments';
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import VImageWithCaption from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VImageWithCaption.vue'
 
 /* preview */
@@ -136,29 +135,17 @@ useHead({
               v-for="(article, index) in articles"
               :key="`${article.id}-${index}`"
             >
-              <v-card
+              <gothamist-card
+                :article="article"
                 class="mod-horizontal mb-5"
-                :image="useImageUrl(article.listingImage)"
-                :title="article.listingTitle"
-                :titleLink="article.link"
-                :ratio="[3, 2]"
                 :width="318"
                 :height="212"
-                :maxWidth="article.listingImage?.width"
-                :maxHeight="article.listingImage?.height"
-                :sizes="[1]"
-                :tags="[
-                  {
-                    name: article.section.name,
-                    slug: `/${article.section.slug}`,
-                  },
-                ]"
               >
                 <p>
                   {{ article.description }}
                 </p>
                 <v-card-metadata :article="article" />
-              </v-card>
+              </gothamist-card>
               <hr class="mb-5" />
               <!-- mid page zone should go after the third article -->
               <div


### PR DESCRIPTION
https://nypublicradio-digital.atlassian.net/browse/GOTH-554
- Filter stories marked as sponsored content from showing up on the home page, index page, recirculation module
- Consolidate card default settings into a gothamist-card component
- Mark sponsored stories as sponsored on the card (but don't show the section tag)
- Add robots:noindex,nofollow meta tag to sponsored stories