### PR TITLE
GOTH-559 Ad layout glitch on article page

### DIFF
--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -76,6 +76,7 @@ const onTagClick = (tag) => {
       flex: 0 0 auto;
       padding: 0.5rem;
       width: 100%;
+      max-width: 730px;
     }
   }
 }


### PR DESCRIPTION
sometimes a wide ad would load in the comment module that would cause the comments column to expand and push the ad in the right sidebar down to the the next row, causing the comments to expand into the newly empty sidebar area.

- set max width on author/comments column