### PR TITLE
Focus new articles when loading more

### DIFF
--- a/components/SectionPageTemplate.vue
+++ b/components/SectionPageTemplate.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { useUpdateCommentCounts } from '~~/composables/comments'
 import { Page } from '~~/composables/types/Page'
 import { nextTick } from 'vue'
@@ -9,7 +8,6 @@ const props = defineProps<{
 }>()
 const route = useRoute()
 
-const initialStoryCount = ref(10)
 const loadMoreStoryCount = ref(10)
 const loadMoreContainer = ref('#articleList')
 const featuredStoryCount = ref(5)

--- a/components/SectionPageTemplate.vue
+++ b/components/SectionPageTemplate.vue
@@ -2,6 +2,7 @@
 import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
 import { useUpdateCommentCounts } from '~~/composables/comments'
 import { Page } from '~~/composables/types/Page'
+import { nextTick } from 'vue'
 
 const props = defineProps<{
   page: Page
@@ -10,6 +11,7 @@ const route = useRoute()
 
 const initialStoryCount = ref(10)
 const loadMoreStoryCount = ref(10)
+const loadMoreContainer = ref('#articleList')
 const featuredStoryCount = ref(5)
 const pageTitle = `${props.page.title} | Gothamist | News For New Yorkers`
 
@@ -31,6 +33,11 @@ const loadMoreArticles = async () => {
     descendant_of: props.page.id,
   })
   articles.value.push(...newArticles)
+  await nextTick()
+  if (newArticles.length) {
+    ([...document.querySelectorAll(`${loadMoreContainer.value} .v-card .card-title-link`)]
+      .slice(-newArticles.length)[0] as HTMLElement).focus()
+  }
 }
 const { $analytics } = useNuxtApp()
 onMounted(() => {
@@ -62,7 +69,7 @@ const newsletterSubmitEvent = () => {
         <HtlAd layout="rectangle" slot="htlad-gothamist_interior_midpage_1" />
       </div>
       <!-- articles -->
-      <div v-if="articles" class="grid gutter-x-xl">
+      <div id="articleList" v-if="articles" class="grid gutter-x-xl">
         <h2 class="sr-only">Latest {{ page.title }} Articles</h2>
         <div class="col-1 hidden xl:block"></div>
         <div class="col">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { useUpdateCommentCounts } from '~~/composables/comments'
 import { ArticlePage } from '~~/composables/types/Page'
-import { computed, ref } from 'vue'
+import { computed, ref, nextTick } from 'vue'
 
 const riverStoryCount = ref(6)
 const riverAdOffset = ref(2)
 const riverAdRepeatRate = ref(6)
+const riverContainer = ref('#latest')
 
 const articlesPromise = findArticlePages({
   limit: riverStoryCount.value,
@@ -49,6 +50,11 @@ const loadMoreArticles = async () => {
     offset: latestArticles.value.length,
   })
   latestArticles.value.push(...newArticles)
+  await nextTick()
+  if (newArticles.length) {
+    ([...document.querySelectorAll(`${riverContainer.value} .v-card .card-title-link`)]
+      .slice(-newArticles.length)[0] as HTMLElement).focus()
+  }
 }
 
 const { $analytics } = useNuxtApp()

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue'
-import VCard from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VCard.vue'
-import useImageUrl from '~~/composables/useImageUrl'
 
 const route = useRoute()
-const router = useRouter()
 const { $analytics } = useNuxtApp()
 const querySlug = ref(route.query.q)
 const query = ref(querySlug.value || '')

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, watch, nextTick } from 'vue'
 
 const route = useRoute()
 const { $analytics } = useNuxtApp()
@@ -12,6 +12,7 @@ let articles = ref(
   )
 )
 const articlesToShow = ref(10)
+const loadMoreContainer = ref('#resultList')
 const isSearching = ref(false)
 
 async function getSearchResults() {
@@ -27,6 +28,16 @@ async function getSearchResults() {
     event_label: `${query.value}`,
   })
   isSearching.value = false
+}
+
+const loadMoreArticles = async () => {
+  const topArticle = articlesToShow.value
+  articlesToShow.value += 6
+  await nextTick()
+  if (topArticle < articles.value.length) {
+    ([...document.querySelectorAll(`${loadMoreContainer.value} .v-card .card-title-link`)]
+      .slice(topArticle)[0] as HTMLElement).focus()
+  }
 }
 
 onMounted(() => {
@@ -89,7 +100,7 @@ const newsletterSubmitEvent = () => {
         <div class="content">
           <!-- search results article river -->
           <template v-if="articles">
-            <div class="grid gutter-x-xl">
+            <div id="resultList" class="grid gutter-x-xl">
               <div class="col-1 hidden xxl:block"></div>
               <div class="col">
                 <div
@@ -121,7 +132,7 @@ const newsletterSubmitEvent = () => {
                   v-if="articlesToShow < articles.length"
                   class="p-button-rounded"
                   label="Load More"
-                  @click="articlesToShow += 6"
+                  @click="loadMoreArticles"
                 >
                 </Button>
               </div>

--- a/pages/staff/[staffSlug].vue
+++ b/pages/staff/[staffSlug].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, nextTick } from 'vue'
 //import { StaffPage } from '../../composables/types/Page'
 import { ArticlePage } from '~~/composables/types/Page';
 
@@ -12,6 +12,7 @@ const staffSlug = route.params.staffSlug
 
 const initialStoryCount = ref(12)
 const loadMoreStoryCount = ref(12)
+const loadMoreContainer = ref('#articleList')
 
 const initialArticles = await findArticlePages({
   author_slug: staffSlug,
@@ -32,6 +33,11 @@ const loadMoreArticles = async () => {
     offset: articles.value.length
   })
   articles.value.push(...newArticles)
+  await nextTick()
+  if (newArticles.length) {
+    ([...document.querySelectorAll(`${loadMoreContainer.value} .v-card .card-title-link`)]
+      .slice(-newArticles.length)[0] as HTMLElement).focus()
+  }
 }
 
 // find a match of the slug in the articles' authors array and return the matched author's data
@@ -95,7 +101,7 @@ useHead({
           </div>
           <div class="col-fixed col-fixed-width-330 hidden xl:block"></div>
         </div>
-        <div class="grid gutter-x-30">
+        <div id="articleList" class="grid gutter-x-30">
           <div v-if="articles" class="col">
             <div
               v-for="(article, index) in articles"

--- a/pages/tags/[tagSlug].vue
+++ b/pages/tags/[tagSlug].vue
@@ -3,6 +3,7 @@ import { TagPage } from '../../composables/types/Page'
 import { StreamfieldBlock, ContentCollectionBlock } from '../../composables/types/StreamfieldBlock'
 import { useUpdateCommentCounts } from '~~/composables/comments';
 import VImageWithCaption from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VImageWithCaption.vue'
+import { nextTick } from 'vue'
 
 /* preview */
 import { usePreviewData } from '~/composables/states'
@@ -15,6 +16,7 @@ const { $analytics, $htlbid } = useNuxtApp()
 const tagSlug = isPreview ? previewData.value.slug : route.params.tagSlug
 const initialStoryCount = ref(10)
 const loadMoreStoryCount = ref(10)
+const loadMoreContainer = ref('#articleList')
 const curatedTagPagePromise = isPreview
   ? previewData.value.data
   : findPage(`tags/${tagSlug}`).then(
@@ -42,6 +44,11 @@ const loadMoreArticles = async () => {
     tag_slug: tagSlug,
   })
   articles.value.push(...newArticles)
+  await nextTick()
+  if (newArticles.length) {
+    ([...document.querySelectorAll(`${loadMoreContainer.value} .v-card .card-title-link`)]
+      .slice(-newArticles.length)[0] as HTMLElement).focus()
+  }
 }
 
 const tagName =
@@ -132,7 +139,7 @@ useHead({
     </section>
     <section v-if="articles">
       <div class="content">
-        <div class="grid gutter-x-30">
+        <div id="articleList" class="grid gutter-x-30">
           <h2 class="sr-only">Latest Articles Tagged "{{ tagName }}"</h2>
           <div class="col">
             <div


### PR DESCRIPTION
After clicking load more, put the focus on the top article of the newly loaded/displayed articles.
On the home page, section pages, tag pages, staff pages, and search page.

Also deleted a bunch of unused imports and variables.