### PR TITLE
Exclude search pages with noindex instead of robots.txt

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -48,9 +48,14 @@ useHeadSafe({
 useServerHeadSafe({
   meta: [{ property: 'og:title', content: pageTitle}]
 })
+if (query.value) {
+  useServerHead({meta: [{name: 'robots', content: 'noindex'}]})
+}
 
 useChartbeat()
 useOptinMonster()
+
+
 
 onMounted(() => {
   $analytics.sendPageView({ page_type: 'search_page' })

--- a/public/robots-prod.txt
+++ b/public/robots-prod.txt
@@ -1,7 +1,6 @@
 User-agent: *
 Disallow: /mt/
 Disallow: /profile/
-Disallow: /search?q=*
 
 Sitemap: https://gothamist.com/sitemap.xml
 Sitemap: https://gothamist.com/sitemap-news.xml


### PR DESCRIPTION
Why not use both?
https://developers.google.com/search/docs/crawling-indexing/block-indexing
> If the page is blocked by a robots.txt file or the crawler can't access the page, the crawler will never see the noindex rule, and the page can still appear in search results, for example if other pages link to it.