### PR TITLE
Set the test_nginx docker image to match the image used for deploy in Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
 
   test_nginx:
     docker:
-      - image: nginx
+      - image: node:16.14.2-slim
     parameters:
       env:
         type: enum


### PR DESCRIPTION
The docker hub `nginx` image was updated recently causing the `test_nginx` job to fail due to some missing dependencies. However, we don't depend on the `nginx` image when actually deploying, so this test failure doesn't reflect a problem we would have in an actual deploy scenario. In other words it's a false positive. I've updated the image used in the `test_nginx` job to match the docker image we use when deploying so we wont have this kind of false positive blocking our builds.