### PR TITLE
Update optinmonster composable to read config from `config.public`

### DIFF
--- a/composables/useOptinMonster.ts
+++ b/composables/useOptinMonster.ts
@@ -1,8 +1,8 @@
 export default function useOptinMonster() {
   onMounted(() => {
     const config = useRuntimeConfig()
-    if (!process.server && window[`om${config.OPTIN_MONSTER_ACCOUNT_ID}_${config.OPTIN_MONSTER_USER_ID}`]) {
-      const optinMonster = window[`om${config.OPTIN_MONSTER_ACCOUNT_ID}_${config.OPTIN_MONSTER_USER_ID}`]
+    if (!process.server && window[`om${config.public.OPTIN_MONSTER_ACCOUNT_ID}_${config.public.OPTIN_MONSTER_USER_ID}`]) {
+      const optinMonster = window[`om${config.public.OPTIN_MONSTER_ACCOUNT_ID}_${config.public.OPTIN_MONSTER_USER_ID}`]
       optinMonster.reset()
       optinMonster.campaigns?.Sessions?.init();
     }


### PR DESCRIPTION
Not explicitly using `config.public` was deprecated in the latest version of nuxt but i think this was merged around the same time as the update and got skipped over.