### PR TITLE
fix email collector form regex

### DIFF
--- a/components/EmailCollectorForm.vue
+++ b/components/EmailCollectorForm.vue
@@ -61,7 +61,9 @@ onMounted(() => {
 
 // function to check if the email is a valid format and to set the error text
 const validateEmail = () => {
-  const validRegex = /^[A-z0-9._%+-]+@[A-z0-9.-]+\.[A-z]{2,3}$/
+  // See also isValidEmail in useNewsletterSignup.ts
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#basic_validation
+  const validRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
   emailErrorText.value = null
   if (validRegex.test(email.value)) {
     return true


### PR DESCRIPTION
Updates the regular expression used in the EmailCollectorForm component to be more permissive. Consistent with @walsh9's regex in `useNewsletterSignup.ts`: <https://github.com/nypublicradio/gothamist-vue3/blob/71d8176513e9c09752479d26a7a6479e418e6db0/composables/useNewsletterSignup.ts#L18>.