### PR TITLE
Block Google-Extended

### DIFF
--- a/public/robots-prod.txt
+++ b/public/robots-prod.txt
@@ -11,5 +11,8 @@ Disallow: /
 User-agent: GPTBot
 Disallow: /
 
+User-agent: Google-Extended
+Disallow: /
+
 Sitemap: https://gothamist.com/sitemap.xml
 Sitemap: https://gothamist.com/sitemap-news.xml


### PR DESCRIPTION
Block the bot that Google users for training LLMs, based on https://blog.google/technology/ai/an-update-on-web-publisher-controls/