### PR TITLE
Update newsletters.vue for newsletter launch

### DIFF
--- a/pages/newsletters.vue
+++ b/pages/newsletters.vue
@@ -11,7 +11,7 @@ const newsletters = [
     description: 'Get links to our top stories delivered to your inbox every day at 5 p.m.',
   },
   {
-    title: 'On the Way',
+    title: 'On The Way',
     id: 'We The Commuters',
     description: 'The week’s transit news, exclusive analysis, answers to your burning commuter questions and more.',
   },

--- a/pages/newsletters.vue
+++ b/pages/newsletters.vue
@@ -11,9 +11,9 @@ const newsletters = [
     description: 'Get links to our top stories delivered to your inbox every day at 5 p.m.',
   },
   {
-    title: 'We the Commuters',
+    title: 'On the Way',
     id: 'We The Commuters',
-    description: 'Essential transportation coverage to your inbox every Thursday.',
+    description: 'The week’s transit news, exclusive analysis, answers to your burning commuter questions and more.',
   },
   {
     title: 'Politics Brief',


### PR DESCRIPTION
Updates the title and description of our transit newsletter to prepare for its new branding.