### PR TITLE
GOTH-643 Fix a11y issues flagged by axe as 'serious'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 cypress/videos/
 cypress/screenshots/
 cypress/downloads/
+.DS_Store

--- a/components/EmailCollectorForm.vue
+++ b/components/EmailCollectorForm.vue
@@ -160,9 +160,7 @@ function submitForm() {
           <div class="field-checkbox mt-3 mb-0">
             <Checkbox
               v-model="checked"
-              role="checkbox"
               aria-label="Toggle agreement to the terms"
-              :aria-checked="checked"
               :disabled="isSubmitting"
               :binary="true"
               @click="!checked"

--- a/components/SearchButton.vue
+++ b/components/SearchButton.vue
@@ -1,6 +1,4 @@
 <script setup>
-import VFlexibleLink from '@nypublicradio/nypr-design-system-vue3/v2/src/components/VFlexibleLink.vue'
-
 defineProps({
   placeholder: {
     type: String,
@@ -19,6 +17,11 @@ function onSearch() {
   emit('onSearch', searchTerm.value)
   return navigateTo({ path: '/search', query: { q: searchTerm.value } })
 }
+
+function goToSearch() {
+  emit('onNavigate')
+  return navigateTo({ path: route.query.q ? '' : '/search' })
+}
 </script>
 
 <template>
@@ -34,35 +37,26 @@ function onSearch() {
         @keypress.enter="onSearch"
       />
       <i style="top: 14px">
-        <VFlexibleLink raw aria-hidden="true" tabindex="-1" @click="onSearch">
-          <Button
-            icon="pi pi-search"
-            class="p-button p-component p-button-icon-only p-button-text p-button-rounded -mr-2"
-            :aria-label="
-              searchTerm
-                ? `See search results for ${searchTerm}`
-                : 'Go to search page'
-            "
-            aria-expanded="false"
-          />
-        </VFlexibleLink>
+        <Button
+          icon="pi pi-search"
+          class="p-button p-component p-button-icon-only p-button-text p-button-rounded -mr-2"
+          :aria-label="
+            searchTerm
+              ? `See search results for ${searchTerm}`
+              : 'Go to search page'
+          "
+          @click="onSearch"
+        />
       </i>
     </span>
-    <VFlexibleLink
+    <Button
       v-else
-      :to="route.query.q ? '' : '/search'"
-      raw
-      aria-hidden="true"
-      tabindex="-1"
-      @click="emit('onNavigate')"
-    >
-      <Button
-        icon="pi pi-search"
-        class="p-button p-component p-button-icon-only p-button-text p-button-rounded -mr-2"
-        aria-label="Go to search page"
-        aria-expanded="false"
-      />
-    </VFlexibleLink>
+      icon="pi pi-search"
+      class="p-button p-component p-button-icon-only p-button-text p-button-rounded -mr-2"
+      aria-label="Go to search page"
+      aria-expanded="false"
+      @click="goToSearch"
+    />
   </div>
 </template>
 

--- a/cypress/e2e/article.cy.ts
+++ b/cypress/e2e/article.cy.ts
@@ -1,4 +1,4 @@
-import { cypressConfig } from '../support/config'
+import { axeConfig } from '../support/config'
 
 describe('An article page', () => {
   beforeEach(() => {
@@ -216,6 +216,6 @@ describe('An article page', () => {
     cy.visit('/news/extra-extra-meet-connecticuts-answer-to-pizza-rat')
     cy.wait('@article')
     cy.injectAxe()
-    cy.checkA11y(null, cypressConfig)
+    cy.checkA11y(null, axeConfig)
   })
 })

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -1,4 +1,4 @@
-import { cypressConfig } from '../support/config'
+import { axeConfig } from '../support/config'
 
 describe('The home page', () => {
   beforeEach(() => {
@@ -80,6 +80,6 @@ describe('The home page', () => {
     cy.visit('/')
     cy.wait(['@index', '@latest'])
     cy.injectAxe()
-    cy.checkA11y(null, cypressConfig)
+    cy.checkA11y(null, axeConfig)
   })
 })

--- a/cypress/e2e/informationpage.cy.ts
+++ b/cypress/e2e/informationpage.cy.ts
@@ -1,4 +1,4 @@
-import { cypressConfig } from '../support/config'
+import { axeConfig } from '../support/config'
 
 describe('An information page', () => {
   beforeEach(() => {
@@ -24,6 +24,6 @@ describe('An information page', () => {
     cy.wait('@draftInformationPreview')
 
     cy.injectAxe()
-    cy.checkA11y(null, cypressConfig)
+    cy.checkA11y(null, axeConfig)
   })
 })

--- a/cypress/e2e/newsletter.cy.ts
+++ b/cypress/e2e/newsletter.cy.ts
@@ -1,4 +1,4 @@
-import { cypressConfig } from '../support/config'
+import { axeConfig } from '../support/config'
 
 describe('The newsletter page', () => {
   beforeEach(() => {
@@ -55,6 +55,6 @@ describe('The newsletter page', () => {
   it('Has no detectable a11y violations on load', () => {
     cy.visit('/newsletters')
     cy.injectAxe()
-    cy.checkA11y(null, cypressConfig)
+    cy.checkA11y(null, axeConfig)
   })
 })

--- a/cypress/e2e/sectionpage.cy.ts
+++ b/cypress/e2e/sectionpage.cy.ts
@@ -1,4 +1,4 @@
-import { cypressConfig } from '../support/config'
+import { axeConfig } from '../support/config'
 
 describe('A section page', () => {
   beforeEach(() => {
@@ -79,6 +79,6 @@ describe('A section page', () => {
     cy.visit('/news')
     cy.wait('@sectionArticles')
     cy.injectAxe()
-    cy.checkA11y(null, cypressConfig)
+    cy.checkA11y(null, axeConfig)
   })
 })

--- a/cypress/e2e/staffpage.cy.ts
+++ b/cypress/e2e/staffpage.cy.ts
@@ -1,4 +1,4 @@
-import { cypressConfig } from '../support/config'
+import { axeConfig } from '../support/config'
 
 describe('A staff page', () => {
   beforeEach(() => {
@@ -46,6 +46,6 @@ describe('A staff page', () => {
     cy.visit('/staff/jen-chung')
     cy.wait('@staffArticles')
     cy.injectAxe()
-    cy.checkA11y(null, cypressConfig)
+    cy.checkA11y(null, axeConfig)
   })
 })

--- a/cypress/e2e/tagpage.cy.ts
+++ b/cypress/e2e/tagpage.cy.ts
@@ -1,4 +1,4 @@
-import { cypressConfig } from '../support/config'
+import { axeConfig } from '../support/config'
 
 describe('A tag page', () => {
   beforeEach(() => {
@@ -67,6 +67,6 @@ describe('A tag page', () => {
     cy.visit('/tags/dogs')
     cy.wait(['@tagPage', '@tagArticles'])
     cy.injectAxe()
-    cy.checkA11y(null, cypressConfig)
+    cy.checkA11y(null, axeConfig)
   })
 })

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -1,5 +1,5 @@
-export const cypressConfig = {
+export const axeConfig = {
   retries: 3,
   interval: 500,
-  includedImpacts: ['critical'],
+  includedImpacts: ['critical', 'serious'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@antfu/eslint-config": "^1.0.0-beta.24",
         "@sentry/vite-plugin": "^2.10.2",
-        "cypress": "^13.3.3",
+        "cypress": "^13.6.0",
         "cypress-axe": "^1.5.0",
         "eslint": "^8.51.0",
         "lint-staged": "^14.0.1",
@@ -6651,9 +6651,9 @@
       "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
     },
     "node_modules/cypress": {
-      "version": "13.3.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.3.tgz",
-      "integrity": "sha512-mbdkojHhKB1xbrj7CrKWHi22uFx9P9vQFiR0sYDZZoK99OMp9/ZYN55TO5pjbXmV7xvCJ4JwBoADXjOJK8aCJw==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.0.tgz",
+      "integrity": "sha512-quIsnFmtj4dBUEJYU4OH0H12bABJpSujvWexC24Ju1gTlKMJbeT6tTO0vh7WNfiBPPjoIXLN+OUqVtiKFs6SGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^1.0.0-beta.24",
     "@sentry/vite-plugin": "^2.10.2",
-    "cypress": "^13.3.3",
+    "cypress": "^13.6.0",
     "cypress-axe": "^1.5.0",
     "eslint": "^8.51.0",
     "lint-staged": "^14.0.1",

--- a/pages/newsletters.vue
+++ b/pages/newsletters.vue
@@ -64,8 +64,8 @@ const newsletterSignup = useNewsletterSignup({
               <div v-for="(newsletter, index) in newsletters" :key="newsletter.id" class="newsletter-list-item">
                 <div class="newsletter-checkbox">
                   <Checkbox
-                    :id="`newsletter-${index}`"
                     v-model="selectedLists"
+                    :input-id="`newsletter-${index}`"
                     :value="newsletter.id"
                   />
                 </div>
@@ -82,9 +82,7 @@ const newsletterSignup = useNewsletterSignup({
               <Checkbox
                 id="agree"
                 v-model="agree"
-                role="checkbox"
                 aria-label="Toggle agreement to the terms"
-                :aria-checked="agree"
                 :disabled="newsletterSignup.isSubmitting.value"
                 :binary="true"
               />


### PR DESCRIPTION
https://nypublicradio-digital.atlassian.net/browse/GOTH-643

- Fix a11y issues with the search button, checkbox on signup forms, and newsletter page.
- Update axe tests to not only fail on 'critical' issues but also 'serious' issues (which now pass because of these changes)
- renamed 'cypressConfig' to 'axeConfig' to leave room for other non-axe configuration