### PR TITLE
add allowurls to sentry config

### DIFF
--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -19,6 +19,11 @@ export default defineNuxtPlugin((nuxtApp) => {
     tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.5 : 1.0,
     replaysSessionSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.05 : 1.0,
     replaysOnErrorSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.05 : 1.0,
+    allowUrls: [
+      'https://gothamist.com',
+      'https://gothamist-vue3.demo.nypr.digital',
+      'https://gothamist-vue3demo.gothamist.com',
+    ],
     tracePropagationTargets: ['cms.demo.nypr.digital', 'api.demo.nypr.digital', 'cms.prod.nypr.digital', 'api.prod.nypr.digital'],
     trackComponents: true,
     timeout: 2000,

--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -17,8 +17,8 @@ export default defineNuxtPlugin((nuxtApp) => {
       new Sentry.Replay(),
     ],
     tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.5 : 1.0,
-    replaysSessionSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.05 : 1.0,
-    replaysOnErrorSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.05 : 1.0,
+    replaysSessionSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.0005 : 1.0,
+    replaysOnErrorSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.001 : 1.0,
     allowUrls: [
       'https://gothamist.com',
       'https://gothamist-vue3.demo.nypr.digital',


### PR DESCRIPTION
https://nypublicradio-digital.atlassian.net/browse/GOTH-646

This should cut down on a lot of unactionable errors from third party sources and make our sentry error reports lessy noisy and more useful.

Also reducing the replay sample rate as we're running up against our replay quota