### PR TITLE
remove nativo from the default template as it's already loaded by the plugin

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -120,11 +120,6 @@ useHead({
   ],
   script: [
     {
-      'src': 'https://s.ntv.io/serve/load.js',
-      'async': true,
-      'data-ntv-set-no-auto-start': '',
-    },
-    {
       src: config.public.HTL_JS,
       async: true,
     },


### PR DESCRIPTION
The removed lines duplicate functionality already in the nuxt plugin https://github.com/nypublicradio/gothamist-vue3/blob/main/plugins/6.nativo.ts#L8-L14