### PR TITLE
Update javascript for better ios compatibility

### DIFF
--- a/composables/dom.js
+++ b/composables/dom.js
@@ -88,7 +88,7 @@ const useStreamfieldLandmarks = function (rootElement) {
     if ([...node.classList].includes(TEXT_CLASS)) {
       const childLandmarks = _getTextFieldLandmarks(node, wordWeight)
       landmarks.push(...childLandmarks);
-      ({ wordWeight } = landmarks.at(-1))
+      ({ wordWeight } = landmarks[landmarks.length - 1])
     }
     else {
       wordWeight += _getWordWeight(node)


### PR DESCRIPTION
Older versions of iOS don't seem to support `Array.at()` and nuxt doesn't seem to compile it away to something else so i'm just going to not use it. 

This should fix an error we've been seeing in sentry: https://nypublicradio.sentry.io/issues/4698353568/?project=6537168