### PR TITLE
Mitigate cypress test flakiness

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,4 +4,8 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
   },
+  retries: {
+    runMode: 2,
+    openMode: 0,
+  },
 })

--- a/cypress/e2e/article.cy.ts
+++ b/cypress/e2e/article.cy.ts
@@ -131,7 +131,7 @@ describe('An article page', () => {
         cy.get('h2.regwall-header').should('contain', 'Read this story completely free')
         cy.get('.regwall-form-wrapper input[type=email]').type(emailAddress)
         cy.wait(500)
-        cy.contains('Sign Up').click()
+        cy.contains('Sign Up').trigger('mouseover').click()
         cy.wait('@emailProxy')
         cy.get('h2.regwall-header').should('contain', 'Thanks for subscribing!')
       })

--- a/cypress/e2e/article.cy.ts
+++ b/cypress/e2e/article.cy.ts
@@ -130,7 +130,7 @@ describe('An article page', () => {
       cy.wait('@oldArticle').then(() => {
         cy.get('h2.regwall-header').should('contain', 'Read this story completely free')
         cy.get('.regwall-form-wrapper input[type=email]').type(emailAddress)
-        cy.wait(200)
+        cy.wait(500)
         cy.contains('Sign Up').click()
         cy.wait('@emailProxy')
         cy.get('h2.regwall-header').should('contain', 'Thanks for subscribing!')

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -61,7 +61,7 @@ describe('The home page', () => {
   it('loads more', () => {
     cy.visit('/')
     cy.wait('@latest')
-    cy.contains('Load More').click()
+    cy.contains('Load More').trigger('mouseover').click()
     cy.wait('@indexMore')
     cy.get('#articleList .gothamist-card').should('have.length', 12)
     cy.get('#articleList .card-title-link').eq(6).should('have.focus')

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -69,11 +69,11 @@ describe('The home page', () => {
   it('hides and shows the fixed header', () => {
     cy.visit('/')
     cy.get('.fixed-header').should('not.exist')
-    cy.scrollTo(0, 500)
-    cy.wait(300)
+    cy.scrollTo(0, 600)
+    cy.wait(400)
     cy.get('.fixed-header').should('exist')
     cy.scrollTo(0, 0)
-    cy.wait(300)
+    cy.wait(400)
     cy.get('.fixed-header').should('not.exist')
   })
   it('has no detectable a11y violations on load', () => {

--- a/cypress/e2e/newsletter.cy.ts
+++ b/cypress/e2e/newsletter.cy.ts
@@ -22,7 +22,7 @@ describe('The newsletter page', () => {
     ).as('emailProxy')
     cy.visit('/newsletters')
     cy.get('.newsletter-form input').first().type(emailAddress)
-    cy.get('#sign-up').click()
+    cy.get('#sign-up').trigger('mouseover').click()
     cy.wait('@emailProxy')
     cy.get('.newsletter-form').contains('Thank you for signing up!')
   })

--- a/cypress/e2e/sectionpage.cy.ts
+++ b/cypress/e2e/sectionpage.cy.ts
@@ -70,7 +70,7 @@ describe('A section page', () => {
   it('loads more', () => {
     cy.visit('/news')
     cy.wait('@sectionArticles')
-    cy.contains('Load More').click()
+    cy.contains('Load More').trigger('mouseover').click()
     cy.wait('@sectionMore')
     cy.get('#articleList .gothamist-card').should('have.length', 30)
     cy.get('#articleList .card-title-link').eq(20).should('have.focus')

--- a/cypress/e2e/staffpage.cy.ts
+++ b/cypress/e2e/staffpage.cy.ts
@@ -37,7 +37,7 @@ describe('A staff page', () => {
   it('loads more', () => {
     cy.visit('/staff/jen-chung')
     cy.wait('@staffArticles')
-    cy.contains('Load More').click()
+    cy.contains('Load More').trigger('mouseover').click()
     cy.wait('@staffMore')
     cy.get('#articleList .gothamist-card').should('have.length', 24)
     cy.get('#articleList .card-title-link').eq(12).should('have.focus')

--- a/cypress/e2e/tagpage.cy.ts
+++ b/cypress/e2e/tagpage.cy.ts
@@ -43,7 +43,7 @@ describe('A tag page', () => {
   it('loads more', () => {
     cy.visit('/tags/dogs')
     cy.wait('@tagArticles')
-    cy.contains('Load More').click()
+    cy.contains('Load More').trigger('mouseover').click()
     cy.wait('@tagMore')
     cy.get('#articleList .gothamist-card').should('have.length', 20)
     cy.get('#articleList .card-title-link').eq(10).should('have.focus')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -49,14 +49,17 @@ Cypress.Commands.add('loadGlobalFixtures', () => {
   cy.intercept('/api/v2/navigation/*', { fixture: 'aviary/navigation.json' }).as('navigation')
   cy.intercept('/api/v4/whats_on/**', { fixture: 'publisher/whats_on.json' }).as('whatsOn')
   cy.intercept({
-    hostname: 'open-api.spot.im',
-  }, { statusCode: 200, body: { messages_count: [] } }).as('commentCounts')
+    hostname: /([^.]*\.)+doubleclick.net/,
+  }, { statusCode: 200, body: '' }).as('doubleclick')
   cy.intercept({
-    hostname: 'api.omappapi.com',
+    hostname: /([^.]*\.)+omappapi.com/,
   }, { statusCode: 200, body: '' }).as('optinMonster')
   cy.intercept({
-    hostname: 'a.omappapi.com',
-  }, { statusCode: 200, body: '' }).as('optinMonster2')
+    hostname: /([^.]*\.)+spot.im/,
+  }, { statusCode: 200, body: '' }).as('openWeb')
+  cy.intercept({
+    hostname: /([^.]*\.)+sentry.io/,
+  }, { statusCode: 200, body: '' }).as('sentry')
   cy.intercept({
     hostname: 'news.google.com',
   }, { statusCode: 200, body: '' }).as('googleNews')

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
       "devDependencies": {
         "@antfu/eslint-config": "^1.0.0-beta.24",
         "@sentry/vite-plugin": "^2.10.2",
-        "cypress": "^13.6.0",
+        "axe-core": "^4.9.0",
+        "cypress": "^13.7.2",
         "cypress-axe": "^1.5.0",
         "eslint": "^8.51.0",
         "lint-staged": "^14.0.1",
@@ -5128,11 +5129,10 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.3.tgz",
-      "integrity": "sha512-d5ZQHPSPkF9Tw+yfyDcRoUOc4g/8UloJJe5J8m4L5+c7AtDdjDLRxew/knnI4CxvtdxEUVgWz4x3OIQUIFiMfw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.0.tgz",
+      "integrity": "sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6183,21 +6183,20 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.2.tgz",
-      "integrity": "sha512-TW3bGdPU4BrfvMQYv1z3oMqj71YI4AlgJgnrycicmPZAXtvywVFZW9DAToshO65D97rCWfG/kqMFsYB6Kp91gQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.2.tgz",
+      "integrity": "sha512-FF5hFI5wlRIHY8urLZjJjj/YvfCBrRpglbZCLr/cYcL9MdDe0+5usa8kTIrDHthlEc9lwihbkb5dmwqBDNS2yw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -6215,7 +6214,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "devDependencies": {
     "@antfu/eslint-config": "^1.0.0-beta.24",
     "@sentry/vite-plugin": "^2.10.2",
-    "cypress": "^13.6.0",
+    "axe-core": "^4.9.0",
+    "cypress": "^13.7.2",
     "cypress-axe": "^1.5.0",
     "eslint": "^8.51.0",
     "lint-staged": "^14.0.1",


### PR DESCRIPTION
This should help with some of the issues we see with cypress tests failing seemingly at random.

- Updated blocking of third-party scripts that we don't want to interfere with tests. (for example random optin monster campaign popups)
- Trigger mouseovers before clicks to make simulated clicks more reliable.
- Increase timing slightly on some of the waits
- Allow failed tests to retry once if (Instead of rerunning the whole test suite)