### PR TITLE
Don't save query params in payload

### DIFF
--- a/composables/useAviary.ts
+++ b/composables/useAviary.ts
@@ -6,6 +6,11 @@ export function transformResponseData(data: Record<string, any>): Record<string,
 
 export default async function useAviary(path: string, options: Record<string, any> = {}) {
   const config = useRuntimeConfig()
+
+  // don't save the query string in the payload
+  const { payload } = useNuxtApp()
+  delete payload?.path
+
   const { data, error } = await useFetch(path, { baseURL: config.public.API_URL, ...options })
   const transformedData = transformResponseData(data)
   return { data: transformedData, error }


### PR DESCRIPTION
This prevents query params from persisting in cached pages