### PR TITLE
Small changes that might help our INP score.

### DIFF
--- a/components/ArticleFooter.vue
+++ b/components/ArticleFooter.vue
@@ -17,7 +17,7 @@ const profileData = isSponsored.value
 // function attached to the emit of the article-tags when clicked
 function onTagClick(tag) {
   if (tag) {
-    $analytics.sendEvent('click_tracking', {
+    $analytics.scheduleEvent('click_tracking', {
       event_category: 'Click Tracking',
       component: 'Article Tags',
       event_label: tag.name,

--- a/components/ArticlePageHeader.vue
+++ b/components/ArticlePageHeader.vue
@@ -69,7 +69,7 @@ function openSidebar(e) {
                 campaign: 'shared_facebook',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Page Header',
                   event_label: 'Social Share Facebook',
@@ -88,7 +88,7 @@ function openSidebar(e) {
                 campaign: 'shared_twitter',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Page Header',
                   event_label: 'Social Share Twitter',
@@ -106,7 +106,7 @@ function openSidebar(e) {
                 campaign: 'shared_reddit',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Page Header',
                   event_label: 'Social Share Reddit',
@@ -124,7 +124,7 @@ function openSidebar(e) {
                 campaign: 'shared_email',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Page Header',
                   event_label: 'Social Share Email',

--- a/components/AudioPlayer.vue
+++ b/components/AudioPlayer.vue
@@ -22,7 +22,7 @@ const playerRef = ref()
 const playerHeight = ref(`${audioPlayerHeight}px`)
 /* function that updated the global useIsEpisodePlaying */
 function updateUseIsEpisodePlaying(e) {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Audio Player play toggle button',
     component: 'Audio Player',
     event_label: `playing = ${e}`,
@@ -31,7 +31,7 @@ function updateUseIsEpisodePlaying(e) {
 }
 /* function that updated the global useIsPlayerMinimized */
 function updateUseIsPlayerMinimized(e) {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Audio Player minimized',
     component: 'Audio Player',
     event_label: `minimized = ${e}`,
@@ -77,7 +77,7 @@ let isInitialPing = true
 function pingEvent() {
   const station = currentEpisodeData.value.name
   const title = currentEpisodeShow.value.title
-  $analytics.sendEvent('event_tracking', {
+  $analytics.scheduleEvent('event_tracking', {
     event_category: 'Ping',
     component: 'Audio Player',
     event_label: `${station} - ${title}`,

--- a/components/Byline.vue
+++ b/components/Byline.vue
@@ -133,7 +133,7 @@ const commentCount = computed(() => {
             campaign: 'shared_facebook',
           }"
           @share="
-            $analytics.sendEvent('click_tracking', {
+            $analytics.scheduleEvent('click_tracking', {
               event_category: 'Click Tracking',
               component: 'Article Byline',
               event_label: 'Social Share Facebook',
@@ -152,7 +152,7 @@ const commentCount = computed(() => {
             campaign: 'shared_twitter',
           }"
           @share="
-            $analytics.sendEvent('click_tracking', {
+            $analytics.scheduleEvent('click_tracking', {
               event_category: 'Click Tracking',
               component: 'Article Byline',
               event_label: 'Social Share Twitter',
@@ -170,7 +170,7 @@ const commentCount = computed(() => {
             campaign: 'shared_reddit',
           }"
           @share="
-            $analytics.sendEvent('click_tracking', {
+            $analytics.scheduleEvent('click_tracking', {
               event_category: 'Click Tracking',
               component: 'Article Byline',
               event_label: 'Social Share Reddit',
@@ -188,7 +188,7 @@ const commentCount = computed(() => {
             campaign: 'shared_email',
           }"
           @share="
-            $analytics.sendEvent('click_tracking', {
+            $analytics.scheduleEvent('click_tracking', {
               event_category: 'Click Tracking',
               component: 'Article Byline',
               event_label: 'Social Share Email',

--- a/components/GothamistCard.vue
+++ b/components/GothamistCard.vue
@@ -117,4 +117,14 @@ div.gothamist-card.sponsored {
 .gothamist-card {
   --tag-bg: transparent;
 }
+
+@media(pointer:coarse) {
+  .image-with-caption-image-link img {
+    transition: transform 0.1s ease-in;
+  }
+  .image-with-caption-image-link:active img {
+    transition: transform 0.1s ease-out;
+    transform: scale(0.97);
+  }
+}
 </style>

--- a/components/GothamistCard.vue
+++ b/components/GothamistCard.vue
@@ -62,7 +62,7 @@ const tags = computed(() => {
 
 const trackClick = function (targetUrl: string) {
   if (props.trackClicks) {
-    $analytics.sendEvent('click_tracking', {
+    $analytics.scheduleEvent('click_tracking', {
       event_category: `Click Tracking - ${props.trackingComponentLocation}`,
       component: props.trackingComponent,
       component_position: props.trackingComponentPosition && String(props.trackingComponentPosition),

--- a/components/GothamistMainHeader.vue
+++ b/components/GothamistMainHeader.vue
@@ -25,7 +25,7 @@ useVisibilityTracking(headerElement, onVisible, onNotVisible)
 
 function trackClick(category, label) {
   // emitted mobile menu click event
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: category,
     component: 'header',
     event_label: label,

--- a/components/InformationPageTemplate.vue
+++ b/components/InformationPageTemplate.vue
@@ -8,7 +8,7 @@ defineProps<{
 const { $analytics } = useNuxtApp()
 
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',

--- a/components/SectionPageTemplate.vue
+++ b/components/SectionPageTemplate.vue
@@ -46,7 +46,7 @@ onMounted(() => {
   useUpdateCommentCounts(articles.value)
 })
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',

--- a/error.vue
+++ b/error.vue
@@ -64,7 +64,7 @@ function handleSidebarShown() {
 
 function trackSidebarClick(label) {
   // emitted mobile menu click event
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Mobile Menu',
     component: 'header',
     event_label: label,
@@ -77,7 +77,7 @@ onBeforeMount(() => {
   updateLiveStream(currentSteamStation.value)
 })
 onMounted(() => {
-  $analytics.sendPageView({ page_type: 'error_page' })
+  $analytics.schedulePageView({ page_type: 'error_page' })
   document.addEventListener('scroll', () => {
     atTop.value = !(window.scrollY > 0)
     // atBottom.value = ((window.scrollY + (window.innerHeight + 115) >= document.body.scrollHeight)) ? true : false
@@ -95,7 +95,7 @@ watch(route, (value) => {
 })
 
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -64,7 +64,7 @@ function handleSidebarShiftTab(e) {
 
 function trackSidebarClick(label) {
   // emitted mobile menu click event
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Mobile Menu',
     component: 'header',
     event_label: label,

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -98,7 +98,7 @@ useChartbeat({
 useOptinMonster()
 
 onMounted(() => {
-  $analytics.sendPageView(trackingData)
+  $analytics.schedulePageView(trackingData)
   $htlbid.setTargeting(adTargetingData)
   sensitiveContent.value = article.sensitiveContent
   useUpdateCommentCounts([article])
@@ -141,7 +141,7 @@ function useInsertAd(targetElement) {
 }
 
 function newsletterSubmitEvent(e) {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: `Click Tracking - ${e} - Newsletter`,
     component: e,
     event_label: 'Newsletter',
@@ -149,7 +149,7 @@ function newsletterSubmitEvent(e) {
 }
 
 function trackWallSeen() {
-  $analytics.sendEvent('view_promotion', {
+  $analytics.scheduleEvent('view_promotion', {
     creative_slot: 'article-registration-wall',
     location_id: '',
     promotion_name: `Registration Wall - ${article.title}`,
@@ -158,7 +158,7 @@ function trackWallSeen() {
 }
 
 function trackSignUp() {
-  $analytics.sendEvent('select_promotion', {
+  $analytics.scheduleEvent('select_promotion', {
     creative_slot: 'article-registration-wall',
     location_id: '',
     promotion_name: `Registration Wall - ${article.title}`,

--- a/pages/[sectionSlug]/index.vue
+++ b/pages/[sectionSlug]/index.vue
@@ -35,13 +35,13 @@ onMounted(() => {
 
   switch (page?.type) {
     case 'information_page':
-      $analytics.sendPageView({
+      $analytics.schedulePageView({
         page_type: 'information_page',
         content_group: 'static-page',
       })
       break
     case 'section_page':
-      $analytics.sendPageView({
+      $analytics.schedulePageView({
         page_type: 'section_page',
         content_group: 'section-front',
       })

--- a/pages/[sectionSlug]/photos/[gallerySlug].vue
+++ b/pages/[sectionSlug]/photos/[gallerySlug].vue
@@ -44,7 +44,7 @@ useChartbeat({
 useOptinMonster()
 
 onMounted(() => {
-  $analytics.sendPageView({
+  $analytics.schedulePageView({
     page_type: 'gallery',
     content_group: article?.sponsoredContent ? 'sponsored-content' : `${route.params.sectionSlug}-gallery`,
   })
@@ -80,7 +80,7 @@ function goBack() {
                 campaign: 'shared_facebook',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Byline',
                   event_label: 'Social Share Facebook',
@@ -98,7 +98,7 @@ function goBack() {
                 campaign: 'shared_twitter',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Byline',
                   event_label: 'Social Share Twitter',
@@ -116,7 +116,7 @@ function goBack() {
                 campaign: 'shared_reddit',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Byline',
                   event_label: 'Social Share Reddit',
@@ -134,7 +134,7 @@ function goBack() {
                 campaign: 'shared_email',
               }"
               @share="
-                $analytics.sendEvent('click_tracking', {
+                $analytics.scheduleEvent('click_tracking', {
                   event_category: 'Click Tracking',
                   component: 'Article Byline',
                   event_label: 'Social Share Email',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -83,7 +83,7 @@ async function loadMoreArticles() {
 const { $analytics, $nativo } = useNuxtApp()
 const cacheControlMaxAge = useCacheControlMaxAge()
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',
@@ -95,7 +95,7 @@ useOptinMonster()
 cacheControlMaxAge.value = CacheControlAgeTime.FIVE_MINUTES
 
 onMounted(() => {
-  $analytics.sendPageView({
+  $analytics.schedulePageView({
     page_type: 'home_page',
     content_group: 'homepage',
   })

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -24,7 +24,7 @@ async function getSearchResults() {
   articles.value = await searchArticlePages({ q: query.value }).then(
     ({ data }) => normalizeSearchArticlePagesResponse(data),
   )
-  $analytics.sendEvent('event_tracking', {
+  $analytics.scheduleEvent('event_tracking', {
     event_category: 'search query',
     content_group: 'search',
     component: 'search page',
@@ -62,7 +62,7 @@ useOptinMonster()
 useCacheControlMaxAge().value = CacheControlAgeTime.FIVE_MINUTES
 
 onMounted(() => {
-  $analytics.sendPageView({ page_type: 'search_page' })
+  $analytics.schedulePageView({ page_type: 'search_page' })
   getSearchResults()
 })
 
@@ -73,7 +73,7 @@ watch(route, (value) => {
 })
 
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',

--- a/pages/sponsored.vue
+++ b/pages/sponsored.vue
@@ -32,7 +32,7 @@ useOptinMonster()
 cacheControlMaxAge.value = CacheControlAgeTime.MONTH
 
 onMounted(() => {
-  $analytics.sendPageView({ page_type: 'sponsored_article' })
+  $analytics.schedulePageView({ page_type: 'sponsored_article' })
   sensitiveContent.value = true
   $nativo.refresh()
 
@@ -48,7 +48,7 @@ onUnmounted(() => {
 })
 
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',

--- a/pages/staff/[staffSlug].vue
+++ b/pages/staff/[staffSlug].vue
@@ -68,7 +68,7 @@ function getAuthorNameFromSlug() {
 
 // emitted event from the newsletter submission form
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',
@@ -80,7 +80,7 @@ useOptinMonster()
 cacheControlMaxAge.value = CacheControlAgeTime.QUARTER
 
 onMounted(() => {
-  $analytics.sendPageView({ page_type: 'staff_page' })
+  $analytics.schedulePageView({ page_type: 'staff_page' })
   $htlbid.setTargeting({ Template: 'Staff' })
 })
 

--- a/pages/tags/[tagSlug].vue
+++ b/pages/tags/[tagSlug].vue
@@ -70,7 +70,7 @@ useOptinMonster()
 cacheControlMaxAge.value = CacheControlAgeTime.QUARTER
 
 onMounted(() => {
-  $analytics.sendPageView({
+  $analytics.schedulePageView({
     page_type: 'tag_page',
     content_group: 'tag-page',
   })
@@ -94,7 +94,7 @@ onUnmounted(() => {
 })
 
 function newsletterSubmitEvent() {
-  $analytics.sendEvent('click_tracking', {
+  $analytics.scheduleEvent('click_tracking', {
     event_category: 'Click Tracking - Footer - Newsletter',
     component: 'footer',
     event_label: 'Newsletter',

--- a/plugins/4.analytics.client.ts
+++ b/plugins/4.analytics.client.ts
@@ -33,11 +33,24 @@ export default defineNuxtPlugin(() => {
       ...params,
     })
   }
+  const scheduleEvent = (name: string, params: Record<string, string>) => {
+    requestIdleCallback(() => {
+      sendEvent(name, params)
+    }, { timeout: 3000 })
+  }
+  const schedulePageView = (params: Record<string, string>) => {
+    requestIdleCallback(() => {
+      sendPageView(params)
+    }, { timeout: 3000 })
+  }
+
   return {
     provide: {
       analytics: {
         sendEvent,
         sendPageView,
+        scheduleEvent,
+        schedulePageView,
       },
     },
   }

--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -9,7 +9,11 @@ export default defineNuxtPlugin((nuxtApp) => {
     app: [vueApp],
     dsn: config.public.SENTRY_DSN,
     integrations: [
-      Sentry.browserTracingIntegration({ router: nuxtApp.$router, enableInp: true }),
+      Sentry.browserTracingIntegration({
+        router: nuxtApp.$router,
+        enableInp: true,
+        interactionsSampleRate: 0.5,
+      }),
       Sentry.replayIntegration(),
     ],
     tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.1 : 1.0,


### PR DESCRIPTION
1. Use `requestIdleCallback()` to defer sending analytics events until the browser is idle so they don't interrupt clicks/interactions.
2. Add a subtle active state to the clickable image links in cards on mobile so users have visual feedback when they tap. Does this count as Next Paint? Not sure.