### PR TITLE
Update Sentry, Lower trace sample rate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@nypublicradio/nypr-design-system-vue3": "^1.0.8",
+        "@sentry/browser": "^7.112.1",
         "@sentry/vue": "^7.109.0",
         "@vueuse/core": "^9.1.0",
         "date-fns": "^3.6.0",
@@ -3467,40 +3468,133 @@
       ]
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.110.0.tgz",
-      "integrity": "sha512-hrfWa3WkSOiBO5Srcr1j4kuGOlbsQic+REpLOofllVIs56DOo9+Aj9svxT+dcvZERv/nlFSV/E0BfGy9g08IEg==",
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.112.1.tgz",
+      "integrity": "sha512-ejE4eRXLqv5emxVWudBkRQCv5Q7s21thei7gqSxGLBXe8AUrCjTiD0qA1ToJAKcleIyRRf/TQvGb/T7U6vwAAw==",
       "dependencies": {
-        "@sentry/core": "7.110.0",
-        "@sentry/types": "7.110.0",
-        "@sentry/utils": "7.110.0"
+        "@sentry/core": "7.112.1",
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.112.1.tgz",
+      "integrity": "sha512-ZhOxt4sZVLqHurWqIY1ExWYZ20ViFTbqgW2GdJGHz4XwJhBln0ZVpHD+tKXy3GBEY+2Ee4qoqHi6tDrFgPvJqw==",
+      "dependencies": {
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.112.1.tgz",
+      "integrity": "sha512-5dLIxWZfCXH5kExrsWc+R6loMr3RR6OQuonVNL3Fa8Dw37Q7aExCrjRmocOHeQKhHwNBd3QhYm7phjnbxS6Oaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/utils": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.112.1.tgz",
+      "integrity": "sha512-/AMGDD6OMvT2cpfL5KuDC10oTS8yOt7BAPomXJNS/xn1TRcEEEZ1TWbYZiGT5ijggQEL1OXSojpeQU8XEW8dcQ==",
+      "dependencies": {
+        "@sentry/types": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.110.0.tgz",
-      "integrity": "sha512-SNa+AfyfX+vc6Xw0pIfDsa5Qnc9cpexU6M2D19gadtVhmep7qoFBuhBVZrSv6BtdCxvrb5EyYsHYGfjQdIDcvg==",
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.112.1.tgz",
+      "integrity": "sha512-+xDd/LEiJZGk4PQKs4xcAWKJFzFKpuNF64DFW/JWuJ5FDnKB+t7w198nQyAZKGjupN7LixLb49Z8O2Gda7fHQQ==",
       "dependencies": {
-        "@sentry/core": "7.110.0",
-        "@sentry/replay": "7.110.0",
-        "@sentry/types": "7.110.0",
-        "@sentry/utils": "7.110.0"
+        "@sentry/core": "7.112.1",
+        "@sentry/replay": "7.112.1",
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.110.0.tgz",
-      "integrity": "sha512-IIHHa9e/mE7uOMJfNELI8adyoELxOy6u6TNCn5t6fphmq84w8FTc9adXkG/FY2AQpglkIvlILojfMROFB2aaAQ==",
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.112.1.tgz",
+      "integrity": "sha512-ZhOxt4sZVLqHurWqIY1ExWYZ20ViFTbqgW2GdJGHz4XwJhBln0ZVpHD+tKXy3GBEY+2Ee4qoqHi6tDrFgPvJqw==",
       "dependencies": {
-        "@sentry/core": "7.110.0",
-        "@sentry/types": "7.110.0",
-        "@sentry/utils": "7.110.0"
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.112.1.tgz",
+      "integrity": "sha512-5dLIxWZfCXH5kExrsWc+R6loMr3RR6OQuonVNL3Fa8Dw37Q7aExCrjRmocOHeQKhHwNBd3QhYm7phjnbxS6Oaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/utils": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.112.1.tgz",
+      "integrity": "sha512-/AMGDD6OMvT2cpfL5KuDC10oTS8yOt7BAPomXJNS/xn1TRcEEEZ1TWbYZiGT5ijggQEL1OXSojpeQU8XEW8dcQ==",
+      "dependencies": {
+        "@sentry/types": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.112.1.tgz",
+      "integrity": "sha512-pZVIOB6+t4HlgU3mCRtIbvo//t8uQY9tnBjbJJ2nEv8nTu8A7/dZ5ebrLOWStV3bNp/+uCqLuLuuimJeNNn6vQ==",
+      "dependencies": {
+        "@sentry/core": "7.112.1",
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.112.1.tgz",
+      "integrity": "sha512-ZhOxt4sZVLqHurWqIY1ExWYZ20ViFTbqgW2GdJGHz4XwJhBln0ZVpHD+tKXy3GBEY+2Ee4qoqHi6tDrFgPvJqw==",
+      "dependencies": {
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.112.1.tgz",
+      "integrity": "sha512-5dLIxWZfCXH5kExrsWc+R6loMr3RR6OQuonVNL3Fa8Dw37Q7aExCrjRmocOHeQKhHwNBd3QhYm7phjnbxS6Oaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.112.1.tgz",
+      "integrity": "sha512-/AMGDD6OMvT2cpfL5KuDC10oTS8yOt7BAPomXJNS/xn1TRcEEEZ1TWbYZiGT5ijggQEL1OXSojpeQU8XEW8dcQ==",
+      "dependencies": {
+        "@sentry/types": "7.112.1"
       },
       "engines": {
         "node": ">=8"
@@ -3516,17 +3610,49 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.110.0.tgz",
-      "integrity": "sha512-gIxedVm6ZgkjQfgCDgLWJgAsolq6OxV8hQ2j1+RaDL2RngvelFo/vlX5f2sD6EbjVp77Cri8u5GkMJF+v4p84g==",
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.112.1.tgz",
+      "integrity": "sha512-NRTo3mJbhiCd9GEFEWL8SplFJhTCPjiAlOhjUw8MnJb7pkxWm2xhC7PVi6SUE8hF/g1rrEwgUr9SX5v8+xwK6g==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.110.0",
-        "@sentry-internal/replay-canvas": "7.110.0",
-        "@sentry-internal/tracing": "7.110.0",
-        "@sentry/core": "7.110.0",
-        "@sentry/replay": "7.110.0",
-        "@sentry/types": "7.110.0",
-        "@sentry/utils": "7.110.0"
+        "@sentry-internal/feedback": "7.112.1",
+        "@sentry-internal/replay-canvas": "7.112.1",
+        "@sentry-internal/tracing": "7.112.1",
+        "@sentry/core": "7.112.1",
+        "@sentry/integrations": "7.112.1",
+        "@sentry/replay": "7.112.1",
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/core": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.112.1.tgz",
+      "integrity": "sha512-ZhOxt4sZVLqHurWqIY1ExWYZ20ViFTbqgW2GdJGHz4XwJhBln0ZVpHD+tKXy3GBEY+2Ee4qoqHi6tDrFgPvJqw==",
+      "dependencies": {
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/types": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.112.1.tgz",
+      "integrity": "sha512-5dLIxWZfCXH5kExrsWc+R6loMr3RR6OQuonVNL3Fa8Dw37Q7aExCrjRmocOHeQKhHwNBd3QhYm7phjnbxS6Oaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/utils": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.112.1.tgz",
+      "integrity": "sha512-/AMGDD6OMvT2cpfL5KuDC10oTS8yOt7BAPomXJNS/xn1TRcEEEZ1TWbYZiGT5ijggQEL1OXSojpeQU8XEW8dcQ==",
+      "dependencies": {
+        "@sentry/types": "7.112.1"
       },
       "engines": {
         "node": ">=8"
@@ -3707,18 +3833,94 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/replay": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.110.0.tgz",
-      "integrity": "sha512-EEpGPf3iBJjWejvoxKLVMnLtLNwPTUxHJV1oxUkbcSi3B/tG5hW7LArYDjAcvkfa4VmA8JLCwj2vYU5MQ8tj6g==",
+    "node_modules/@sentry/integrations": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.112.1.tgz",
+      "integrity": "sha512-jIgXT+ahUS7zmhDMAzsgQHCNA6ZwZAp0Bwjoz0tcuGzNcv7mOCnjHz5YooJVQgXuREV653RmEuGGTklrpn6S2w==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.110.0",
-        "@sentry/core": "7.110.0",
-        "@sentry/types": "7.110.0",
-        "@sentry/utils": "7.110.0"
+        "@sentry/core": "7.112.1",
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations/node_modules/@sentry/core": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.112.1.tgz",
+      "integrity": "sha512-ZhOxt4sZVLqHurWqIY1ExWYZ20ViFTbqgW2GdJGHz4XwJhBln0ZVpHD+tKXy3GBEY+2Ee4qoqHi6tDrFgPvJqw==",
+      "dependencies": {
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations/node_modules/@sentry/types": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.112.1.tgz",
+      "integrity": "sha512-5dLIxWZfCXH5kExrsWc+R6loMr3RR6OQuonVNL3Fa8Dw37Q7aExCrjRmocOHeQKhHwNBd3QhYm7phjnbxS6Oaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations/node_modules/@sentry/utils": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.112.1.tgz",
+      "integrity": "sha512-/AMGDD6OMvT2cpfL5KuDC10oTS8yOt7BAPomXJNS/xn1TRcEEEZ1TWbYZiGT5ijggQEL1OXSojpeQU8XEW8dcQ==",
+      "dependencies": {
+        "@sentry/types": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.112.1.tgz",
+      "integrity": "sha512-4lobxfgmbB2C7ZHk1inWt9IRIvlQa2Sczau5ngE4Qd4mZSKIgIYGtIJC52uOuGvBcP8gHiIbA7ACihkd7834Ew==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.112.1",
+        "@sentry/core": "7.112.1",
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/core": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.112.1.tgz",
+      "integrity": "sha512-ZhOxt4sZVLqHurWqIY1ExWYZ20ViFTbqgW2GdJGHz4XwJhBln0ZVpHD+tKXy3GBEY+2Ee4qoqHi6tDrFgPvJqw==",
+      "dependencies": {
+        "@sentry/types": "7.112.1",
+        "@sentry/utils": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/types": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.112.1.tgz",
+      "integrity": "sha512-5dLIxWZfCXH5kExrsWc+R6loMr3RR6OQuonVNL3Fa8Dw37Q7aExCrjRmocOHeQKhHwNBd3QhYm7phjnbxS6Oaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/utils": {
+      "version": "7.112.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.112.1.tgz",
+      "integrity": "sha512-/AMGDD6OMvT2cpfL5KuDC10oTS8yOt7BAPomXJNS/xn1TRcEEEZ1TWbYZiGT5ijggQEL1OXSojpeQU8XEW8dcQ==",
+      "dependencies": {
+        "@sentry/types": "7.112.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
@@ -3768,6 +3970,77 @@
       },
       "peerDependencies": {
         "vue": "2.x || 3.x"
+      }
+    },
+    "node_modules/@sentry/vue/node_modules/@sentry-internal/feedback": {
+      "version": "7.110.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.110.0.tgz",
+      "integrity": "sha512-hrfWa3WkSOiBO5Srcr1j4kuGOlbsQic+REpLOofllVIs56DOo9+Aj9svxT+dcvZERv/nlFSV/E0BfGy9g08IEg==",
+      "dependencies": {
+        "@sentry/core": "7.110.0",
+        "@sentry/types": "7.110.0",
+        "@sentry/utils": "7.110.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/vue/node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.110.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.110.0.tgz",
+      "integrity": "sha512-SNa+AfyfX+vc6Xw0pIfDsa5Qnc9cpexU6M2D19gadtVhmep7qoFBuhBVZrSv6BtdCxvrb5EyYsHYGfjQdIDcvg==",
+      "dependencies": {
+        "@sentry/core": "7.110.0",
+        "@sentry/replay": "7.110.0",
+        "@sentry/types": "7.110.0",
+        "@sentry/utils": "7.110.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/vue/node_modules/@sentry-internal/tracing": {
+      "version": "7.110.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.110.0.tgz",
+      "integrity": "sha512-IIHHa9e/mE7uOMJfNELI8adyoELxOy6u6TNCn5t6fphmq84w8FTc9adXkG/FY2AQpglkIvlILojfMROFB2aaAQ==",
+      "dependencies": {
+        "@sentry/core": "7.110.0",
+        "@sentry/types": "7.110.0",
+        "@sentry/utils": "7.110.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/vue/node_modules/@sentry/browser": {
+      "version": "7.110.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.110.0.tgz",
+      "integrity": "sha512-gIxedVm6ZgkjQfgCDgLWJgAsolq6OxV8hQ2j1+RaDL2RngvelFo/vlX5f2sD6EbjVp77Cri8u5GkMJF+v4p84g==",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.110.0",
+        "@sentry-internal/replay-canvas": "7.110.0",
+        "@sentry-internal/tracing": "7.110.0",
+        "@sentry/core": "7.110.0",
+        "@sentry/replay": "7.110.0",
+        "@sentry/types": "7.110.0",
+        "@sentry/utils": "7.110.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/vue/node_modules/@sentry/replay": {
+      "version": "7.110.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.110.0.tgz",
+      "integrity": "sha512-EEpGPf3iBJjWejvoxKLVMnLtLNwPTUxHJV1oxUkbcSi3B/tG5hW7LArYDjAcvkfa4VmA8JLCwj2vYU5MQ8tj6g==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.110.0",
+        "@sentry/core": "7.110.0",
+        "@sentry/types": "7.110.0",
+        "@sentry/utils": "7.110.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sideway/address": {
@@ -10676,6 +10949,11 @@
       "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.0.tgz",
       "integrity": "sha512-ZBGjl0ZMEMeOC3Ns0wUF/5UdUmr3qQhBSCniT0LxOgGGIRHiNFOkMtIHB7EOznRU47V2AxPgiVP+s+0/UCU0Hg=="
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/immutable": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
@@ -11740,6 +12018,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -12171,6 +12457,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@nypublicradio/nypr-design-system-vue3": "^1.0.8",
+    "@sentry/browser": "^7.112.1",
     "@sentry/vue": "^7.109.0",
     "@vueuse/core": "^9.1.0",
     "date-fns": "^3.6.0",

--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -12,7 +12,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       Sentry.browserTracingIntegration({ router: nuxtApp.$router, enableInp: true }),
       Sentry.replayIntegration(),
     ],
-    tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.5 : 1.0,
+    tracesSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.1 : 1.0,
     replaysSessionSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.0005 : 1.0,
     replaysOnErrorSampleRate: config.public.SENTRY_ENV.toUpperCase() === 'PROD' ? 0.001 : 1.0,
     allowUrls: [


### PR DESCRIPTION
- Update Sentry version
- Lower trace sample rate

This is to deal with the sudden spike in transactions since #363 
Not sure if it was due to the sentry version or something else.  We can alway increase this again if we need to, once the quota is under control. This should also lower traces from interactions if it had something to do with the new INP measurements (even though we hadn't enabled them yet in the above PR)