### PR TITLE
adding in fallbacks for titles and descriptions

### DIFF
--- a/composables/data/basePages.ts
+++ b/composables/data/basePages.ts
@@ -25,6 +25,6 @@ export function normalizePage(page: Record<string, any>): Page {
     socialImage: page.socialImage,
 
     seoTitle: page.meta?.seoTitle || page.title,
-    searchDescription: page.meta?.searchDescription || page.title,
+    searchDescription: page.meta?.searchDescription || page.description,
   }
 }

--- a/composables/metadata.ts
+++ b/composables/metadata.ts
@@ -145,6 +145,7 @@ function useArticlePageHeadMetadata(article: ArticlePage): { meta: ({ name: stri
       { rel: 'canonical', href: article?.url },
     ],
     meta: [
+      { name: 'description', content: article.searchDescription || article.description },
       { property: 'og:title', content: article.socialTitle },
       { property: 'og:description', content: article.socialDescription },
       { property: 'og:url', content: article.url },

--- a/pages/[sectionSlug]/[articleSlug].vue
+++ b/pages/[sectionSlug]/[articleSlug].vue
@@ -67,8 +67,9 @@ const contentLocked = ref(false) // starts unlocked for ssr, we check content wa
 const isMounted = ref(false)
 
 useHead({
-  title: `${article.seoTitle} - Gothamist`,
+  title: article.seoTitle ? `${article.seoTitle} - Gothamist` : `${article.title} - Gothamist`,
 })
+
 if (article.preventSearchIndexing) {
   useServerHead({
     meta: [{ name: 'robots', content: 'noindex' }],


### PR DESCRIPTION
per Kareem's SEO audit, adding in fallbacks so the article pages have unique titles and descriptions