### PR TITLE
Revised FE-180

### DIFF
--- a/composables/metadata.ts
+++ b/composables/metadata.ts
@@ -144,7 +144,7 @@ function useArticlePageHeadMetadata(article: ArticlePage): { meta: ({ name: stri
   const config = useRuntimeConfig()
   const metadata = {
     meta: [
-      { name: 'description', content: article.searchDescription || article.description, tagPriority: META_TAG_PRIORITY },
+      { name: 'description', content: article.searchDescription ? article.searchDescription : 'Gothamist is a non-profit local newsroom, powered by WNYC.', tagPriority: META_TAG_PRIORITY },
       { property: 'og:title', content: article.socialTitle, tagPriority: META_TAG_PRIORITY },
       { property: 'og:description', content: article.socialDescription, tagPriority: META_TAG_PRIORITY },
       { property: 'og:url', content: article.url, tagPriority: META_TAG_PRIORITY },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -113,7 +113,7 @@ useHead({
   // meta: [
   // {
   // name: 'description',
-  // content: 'Gothamist is a non-profit local newsroom, powered by WNYC. Test this',
+  // content: 'Gothamist is a non-profit local newsroom, powered by WNYC.',
   // tagPriority: META_TAG_PRIORITY,
   // },
   // ],

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -110,13 +110,13 @@ useHead({
     lang: 'en',
   },
   title: 'Gothamist: New York City Local News, Food, Arts & Events',
-  meta: [
-    {
-      name: 'description',
-      content: 'Gothamist is a non-profit local newsroom, powered by WNYC.',
-      tagPriority: META_TAG_PRIORITY,
-    },
-  ],
+  // meta: [
+  // {
+  // name: 'description',
+  // content: 'Gothamist is a non-profit local newsroom, powered by WNYC. Test this',
+  // tagPriority: META_TAG_PRIORITY,
+  // },
+  // ],
   link: [
     { rel: 'preconnect', href: config.public.API_URL },
   ],


### PR DESCRIPTION
Per FE-180 modified metadata.ts and default.vue to ensure the proper meta description, containing a summary of the article’s contents, remains when the article is fully rendered.