### PR TITLE
Update robots-prod.txt

### DIFF
--- a/public/robots-prod.txt
+++ b/public/robots-prod.txt
@@ -16,5 +16,8 @@ Disallow: /
 User-agent: Google-Extended
 Disallow: /
 
+User-agent: PerplexityBot
+Disallow: /
+
 Sitemap: https://gothamist.com/sitemap.xml
 Sitemap: https://gothamist.com/sitemap-news.xml


### PR DESCRIPTION
Update robots.txt for production to exclude the Perplexity crawler (which just updated its terms to clarify that it respects `robots.txt` directives).