### PR TITLE
Fix for CORS errors on XHR/fetch requests.

### DIFF
--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -28,7 +28,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       'Load failed',
     ],
     maxValueLength: 1000,
-    tracePropagationTargets: ['cms.demo.nypr.digital', 'api.demo.nypr.digital', 'cms.prod.nypr.digital', 'api.prod.nypr.digital'],
+    tracePropagationTargets: ['cms.demo.nypr.digital', 'cms.prod.nypr.digital'],
     trackComponents: true,
     timeout: 2000,
     hooks: ['activate', 'mount', 'update'],


### PR DESCRIPTION
Sentry was attaching `sentry-trace` headers to requests to the `api.*.nypr.digital` servers, but those servers weren't configured to accept these headers so we were getting CORS errors.  Since we don't have Sentry set up on those APIs, we don't need to use Sentry's trace propagation feature here so I'm removing them from this list.