### PR TITLE
FE-193: Adding Safari tag to Gothamist

### DIFF
--- a/composables/metadata.ts
+++ b/composables/metadata.ts
@@ -153,6 +153,7 @@ function useArticlePageHeadMetadata(article: ArticlePage): { meta: ({ name: stri
       { property: 'og:image:height', content: '650', tagPriority: META_TAG_PRIORITY },
       { property: 'og:image:alt', content: article.socialImage?.alt, tagPriority: META_TAG_PRIORITY },
       { name: 'twitter:card', content: 'summary_large_image', tagPriority: META_TAG_PRIORITY },
+      { name: 'apple-itunes-app', content: `app-id=470219771, app-argument=wnyc://story/${article.id}?src=wagtail`, tagPriority: META_TAG_PRIORITY },
       { name: 'article:published_time', content: article.publicationDate?.toISOString() },
       { name: 'article:modified_time', content: article.updatedDate?.toISOString() ?? '' },
       { name: 'article:section', content: article.section.name },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -170,6 +170,7 @@ else {
       { property: 'fb:app_id', content: '151261804904925', tagPriority: META_TAG_PRIORITY },
       { name: 'twitter:card', content: 'summary_large_image', tagPriority: META_TAG_PRIORITY },
       { name: 'twitter:site', content: '@gothamist', tagPriority: META_TAG_PRIORITY },
+      { name: 'apple-itunes-app', content: 'app-id=470219771, app-argument=wnyc://', tagPriority: META_TAG_PRIORITY },
     ],
   })
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -130,7 +130,7 @@ export default defineNuxtConfig({
       HTL_IS_TESTING: process.env.HTL_IS_TESTING ?? 'yes',
       API_URL: process.env.API_URL ?? 'https://cms.demo.nypr.digital/api/v2',
       IMAGE_BASE_URL: process.env.IMAGE_BASE_URL ?? 'https://cms.demo.nypr.digital/images/',
-      IMAGE_CDN_URL: process.env.IMAGE_CDN_URL ?? 'https://cdn.cms.nypr.digital',
+      IMAGE_CDN_URL: process.env.IMAGE_CDN_URL ?? 'https://cdn.cms.demo.nypr.digital',
       GA_MEASUREMENT_ID: process.env.GA_MEASUREMENT_ID ?? 'G-3Y8891NN3P',
       GTM_ID: process.env.GTM_ID ?? 'GTM-W6RXBNS',
       NEWSLETTER_API: process.env.NEWSLETTER_API ?? 'https://api.demo.nypr.digital/email-proxy/subscribe',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -130,7 +130,7 @@ export default defineNuxtConfig({
       HTL_IS_TESTING: process.env.HTL_IS_TESTING ?? 'yes',
       API_URL: process.env.API_URL ?? 'https://cms.demo.nypr.digital/api/v2',
       IMAGE_BASE_URL: process.env.IMAGE_BASE_URL ?? 'https://cms.demo.nypr.digital/images/',
-      IMAGE_CDN_URL: process.env.IMAGE_CDN_URL ?? 'https://cdn.cms.demo.nypr.digital',
+      IMAGE_CDN_URL: process.env.IMAGE_CDN_URL ?? 'https://cdn.cms.nypr.digital',
       GA_MEASUREMENT_ID: process.env.GA_MEASUREMENT_ID ?? 'G-3Y8891NN3P',
       GTM_ID: process.env.GTM_ID ?? 'GTM-W6RXBNS',
       NEWSLETTER_API: process.env.NEWSLETTER_API ?? 'https://api.demo.nypr.digital/email-proxy/subscribe',


### PR DESCRIPTION
To improve uptake of the app in the form of downloads we've added tags to Gothamist.com to enable a smart banner promoting the app. 