### PR TITLE
Turn off sentry trace propagation for now

### DIFF
--- a/plugins/sentry.client.js
+++ b/plugins/sentry.client.js
@@ -28,7 +28,6 @@ export default defineNuxtPlugin((nuxtApp) => {
       'Load failed',
     ],
     maxValueLength: 1000,
-    tracePropagationTargets: ['cms.demo.nypr.digital', 'cms.prod.nypr.digital'],
     trackComponents: true,
     timeout: 2000,
     hooks: ['activate', 'mount', 'update'],


### PR DESCRIPTION
I don't think we've actually ever used this to debug anything and it's adding headers that are causing various CORS issues so I'm disabling it for the time being.