### PR TITLE
BE-86 Send canonical CMS site for RSS feeds

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -94,6 +94,13 @@ http {
         set_by_lua_block $wagtail_host {
             return "cms." .. ngx.shared.upstream:get("env") .. ".nypr.digital"
         }
+        set_by_lua_block $cms_site {
+            local env = ngx.shared.upstream:get("env")
+            if env == "prod" then
+                return "gothamist.com:443"
+            end
+            return "gothamist-vue3demo.gothamist.com:443"
+        }
         set_by_lua_block $nuxt_host {
             return "gothamist-vue3." .. ngx.shared.upstream:get("env") .. ".nypr.digital"
         }
@@ -211,7 +218,7 @@ http {
             proxy_pass $wagtail_origin$request_uri/;
             proxy_set_header Host $wagtail_host;
             proxy_set_header Origin $wagtail_origin;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-CMS-Site $cms_site;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;


### PR DESCRIPTION
## Summary

- select the canonical CMS site for RSS requests by deployment environment
- send `X-CMS-Site: gothamist.com:443` in production
- send `X-CMS-Site: gothamist-vue3demo.gothamist.com:443` outside production
- remove the RSS proxy's dependency on `X-Forwarded-Host`

## Why

The CMS needs an explicit site identifier so Gothamist RSS content and generated URLs cannot drift to another frontend domain. This is the proxy-side counterpart to the CMS multisite feed fix.

Jira: [BE-86](https://nypublicradio-digital.atlassian.net/browse/BE-86)  
Support report: [SUP-9273](https://nypublicradio-digital.atlassian.net/browse/SUP-9273)  
CMS PR: [nypublicradio/cms#543](https://github.com/nypublicradio/cms/pull/543)

## Validation

- both site identifiers were verified against the corresponding live CMS environments
- `git diff --check` passed
- repository CI runs `nginx -t` with `nginx-extras`

## Deployment note

Deploy with the CMS PR so the new `X-CMS-Site` header is resolved before the feed stops using `X-Forwarded-Host`.

[BE-86]: https://nypublicradio-digital.atlassian.net/browse/BE-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUP-9273]: https://nypublicradio-digital.atlassian.net/browse/SUP-9273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ